### PR TITLE
feat: add judging operations dashboard

### DIFF
--- a/images.d.ts
+++ b/images.d.ts
@@ -1,0 +1,4 @@
+declare module "*.png" {
+  const value: import("next/image").StaticImageData;
+  export default value;
+}

--- a/src/app/(admin)/admin/_components/dashboard-overview.tsx
+++ b/src/app/(admin)/admin/_components/dashboard-overview.tsx
@@ -1,0 +1,58 @@
+import { Activity, Building2, CheckCircle2, FileWarning, LoaderCircle } from "lucide-react";
+import { getDashboardOverview } from "../_lib/dashboard";
+
+const cards = [
+  {
+    key: "inProgressPrograms",
+    label: "진행 중 프로그램",
+    icon: Activity,
+    color: "text-blue-600",
+  },
+  {
+    key: "totalCompanies",
+    label: "전체 기업 수",
+    icon: Building2,
+    color: "text-neutral-700",
+  },
+  {
+    key: "completedCompanies",
+    label: "평가 완료 기업",
+    icon: CheckCircle2,
+    color: "text-emerald-600",
+  },
+  {
+    key: "pendingCompanies",
+    label: "미평가/진행 중 기업",
+    icon: LoaderCircle,
+    color: "text-amber-600",
+  },
+  {
+    key: "feedbackMissingCount",
+    label: "피드백 누락 건",
+    icon: FileWarning,
+    color: "text-rose-600",
+  },
+] as const;
+
+export async function DashboardOverview() {
+  const overview = await getDashboardOverview();
+
+  return (
+    <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-5">
+      {cards.map(({ key, label, icon: Icon, color }) => (
+        <article
+          key={key}
+          className="rounded-2xl border border-neutral-200 bg-white p-5 shadow-sm"
+        >
+          <div className="mb-4 flex items-center justify-between">
+            <p className="text-sm font-medium text-neutral-500">{label}</p>
+            <Icon className={`h-4 w-4 ${color}`} />
+          </div>
+          <div className="text-3xl font-semibold tracking-tight text-neutral-950">
+            {overview[key].toLocaleString()}
+          </div>
+        </article>
+      ))}
+    </section>
+  );
+}

--- a/src/app/(admin)/admin/_components/dashboard-section-skeleton.tsx
+++ b/src/app/(admin)/admin/_components/dashboard-section-skeleton.tsx
@@ -1,0 +1,35 @@
+export function DashboardCardsSkeleton() {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-5">
+      {Array.from({ length: 5 }).map((_, index) => (
+        <div
+          key={index}
+          className="rounded-2xl border border-neutral-200 bg-white p-5"
+        >
+          <div className="mb-3 h-4 w-24 animate-pulse rounded bg-neutral-200" />
+          <div className="h-8 w-16 animate-pulse rounded bg-neutral-200" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function DashboardTableSkeleton({ rows = 5 }: { rows?: number }) {
+  return (
+    <div className="rounded-2xl border border-neutral-200 bg-white p-4">
+      <div className="mb-4 h-5 w-48 animate-pulse rounded bg-neutral-200" />
+      <div className="space-y-3">
+        {Array.from({ length: rows }).map((_, index) => (
+          <div key={index} className="grid grid-cols-6 gap-3">
+            {Array.from({ length: 6 }).map((__, cellIndex) => (
+              <div
+                key={cellIndex}
+                className="h-10 animate-pulse rounded bg-neutral-100"
+              />
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(admin)/admin/_components/pending-companies-table.tsx
+++ b/src/app/(admin)/admin/_components/pending-companies-table.tsx
@@ -1,0 +1,95 @@
+import Link from "next/link";
+import { AlertTriangle, ArrowRight } from "lucide-react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { getPendingCompanyRows } from "../_lib/dashboard";
+
+export async function PendingCompaniesTable() {
+  const rows = await getPendingCompanyRows();
+
+  return (
+    <section className="rounded-2xl border border-neutral-200 bg-white shadow-sm">
+      <div className="border-b border-neutral-100 px-5 py-4">
+        <div className="flex items-center gap-2">
+          <AlertTriangle className="h-4 w-4 text-amber-600" />
+          <h2 className="text-base font-semibold text-neutral-950">
+            조치가 필요한 기업
+          </h2>
+        </div>
+        <p className="mt-1 text-sm text-neutral-500">
+          미평가 상태이거나 피드백이 누락된 기업을 우선적으로 보여줍니다.
+        </p>
+      </div>
+
+      {rows.length === 0 ? (
+        <div className="px-5 py-10 text-sm text-neutral-500">
+          현재 조치가 필요한 기업이 없습니다.
+        </div>
+      ) : (
+        <div className="overflow-x-auto px-2 pb-2">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>프로그램</TableHead>
+                <TableHead>기업명</TableHead>
+                <TableHead className="text-center">배정 심사위원</TableHead>
+                <TableHead className="text-center">완료 심사위원</TableHead>
+                <TableHead className="text-center">완료율</TableHead>
+                <TableHead className="text-center">상태</TableHead>
+                <TableHead className="text-right">액션</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.map((row) => (
+                <TableRow key={`${row.judgingRoundId}:${row.companyId}`}>
+                  <TableCell className="text-sm text-neutral-700">
+                    {row.programName}
+                  </TableCell>
+                  <TableCell className="font-medium text-neutral-900">
+                    {row.companyName}
+                  </TableCell>
+                  <TableCell className="text-center tabular-nums">
+                    {row.assignedJudges}
+                  </TableCell>
+                  <TableCell className="text-center tabular-nums">
+                    {row.completedJudges}
+                  </TableCell>
+                  <TableCell className="text-center tabular-nums">
+                    {row.completionRate}%
+                  </TableCell>
+                  <TableCell className="text-center">
+                    <Badge
+                      className={
+                        row.feedbackMissing
+                          ? "bg-rose-50 text-rose-700 border-rose-200"
+                          : "bg-amber-50 text-amber-700 border-amber-200"
+                      }
+                    >
+                      {row.statusLabel}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <Link
+                      href={`/admin/${row.judgingRoundId}`}
+                      className="inline-flex items-center gap-1 text-sm font-medium text-neutral-900 underline underline-offset-4"
+                    >
+                      상세 보기
+                      <ArrowRight className="h-3.5 w-3.5" />
+                    </Link>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/app/(admin)/admin/_components/program-status-table.tsx
+++ b/src/app/(admin)/admin/_components/program-status-table.tsx
@@ -1,0 +1,96 @@
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { getProgramDashboardRows, getProgramStatusBadge } from "../_lib/dashboard";
+
+export async function ProgramStatusTable() {
+  const rows = await getProgramDashboardRows();
+
+  return (
+    <section className="rounded-2xl border border-neutral-200 bg-white shadow-sm">
+      <div className="border-b border-neutral-100 px-5 py-4">
+        <h2 className="text-base font-semibold text-neutral-950">
+          프로그램별 심사 운영 현황
+        </h2>
+        <p className="mt-1 text-sm text-neutral-500">
+          운영자가 완료율이 낮거나 누락이 많은 프로그램을 빠르게 찾을 수 있도록 정렬했습니다.
+        </p>
+      </div>
+
+      <div className="overflow-x-auto px-2 pb-2">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>프로그램</TableHead>
+              <TableHead className="text-center">상태</TableHead>
+              <TableHead className="text-center">기업 수</TableHead>
+              <TableHead className="text-center">완료</TableHead>
+              <TableHead className="text-center">대기</TableHead>
+              <TableHead className="text-center">완료율</TableHead>
+              <TableHead className="text-center">피드백 누락</TableHead>
+              <TableHead className="text-right">액션</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.map((row) => {
+              const badge = getProgramStatusBadge(row.status);
+              return (
+                <TableRow key={row.judgingRoundId}>
+                  <TableCell>
+                    <div>
+                      <div className="font-medium text-neutral-900">{row.programName}</div>
+                      <div className="text-xs text-neutral-500">
+                        심사 라운드 ID: {row.judgingRoundId}
+                      </div>
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-center">
+                    <Badge className={badge.className}>{badge.label}</Badge>
+                  </TableCell>
+                  <TableCell className="text-center tabular-nums">{row.totalCompanies}</TableCell>
+                  <TableCell className="text-center tabular-nums text-emerald-700">
+                    {row.completedCompanies}
+                  </TableCell>
+                  <TableCell className="text-center tabular-nums text-amber-700">
+                    {row.pendingCompanies}
+                  </TableCell>
+                  <TableCell className="text-center">
+                    <div className="flex items-center justify-center gap-2">
+                      <div className="h-2 w-20 overflow-hidden rounded-full bg-neutral-100">
+                        <div
+                          className="h-full rounded-full bg-neutral-900"
+                          style={{ width: `${row.completionRate}%` }}
+                        />
+                      </div>
+                      <span className="text-sm tabular-nums text-neutral-700">
+                        {row.completionRate}%
+                      </span>
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-center tabular-nums">
+                    {row.feedbackMissingCount}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <Link
+                      href={`/admin/${row.judgingRoundId}`}
+                      className="text-sm font-medium text-neutral-900 underline underline-offset-4"
+                    >
+                      상세 보기
+                    </Link>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </div>
+    </section>
+  );
+}

--- a/src/app/(admin)/admin/_components/side-nav.tsx
+++ b/src/app/(admin)/admin/_components/side-nav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Users, Building2, FolderKanban, Menu } from "lucide-react";
+import { Users, Building2, FolderKanban, LayoutDashboard, Menu } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import Image from "next/image";
@@ -11,6 +11,12 @@ import { Button } from "@/components/ui/button";
 import { useState } from "react";
 
 const navItems = [
+  {
+    href: "/admin",
+    label: "운영 대시보드",
+    icon: LayoutDashboard,
+    key: "/admin",
+  },
   { href: "/admin/user", label: "사용자 관리", icon: Users, key: "user" },
   {
     href: "/admin/program",

--- a/src/app/(admin)/admin/_lib/dashboard.ts
+++ b/src/app/(admin)/admin/_lib/dashboard.ts
@@ -1,0 +1,290 @@
+import { createClient } from "@/lib/supabase/server";
+
+type RoundRow = {
+  id: string;
+  status: "PENDING" | "IN_PROGRESS" | "COMPLETED";
+  program: {
+    id: number;
+    name: string;
+    start_date: string | null;
+    end_date: string | null;
+  } | null;
+};
+
+type CompanyRow = {
+  judging_round_id: string;
+  company_id: number;
+  company: {
+    name: string;
+  } | null;
+};
+
+type UserRow = {
+  judging_round_id: string;
+  user_id: string;
+};
+
+type CriteriaRow = {
+  judging_round_id: string;
+  id: number;
+};
+
+type EvaluationRow = {
+  judging_round_id: string;
+  company_id: number;
+  user_id: string | null;
+  evaluation_criterion_id: number;
+  feedback: string | null;
+};
+
+export type DashboardOverview = {
+  inProgressPrograms: number;
+  totalCompanies: number;
+  completedCompanies: number;
+  pendingCompanies: number;
+  feedbackMissingCount: number;
+};
+
+export type ProgramDashboardRow = {
+  judgingRoundId: string;
+  programId: number;
+  programName: string;
+  status: "PENDING" | "IN_PROGRESS" | "COMPLETED";
+  totalCompanies: number;
+  completedCompanies: number;
+  pendingCompanies: number;
+  completionRate: number;
+  feedbackMissingCount: number;
+};
+
+export type PendingCompanyRow = {
+  judgingRoundId: string;
+  programName: string;
+  companyId: number;
+  companyName: string;
+  assignedJudges: number;
+  completedJudges: number;
+  completionRate: number;
+  feedbackMissing: boolean;
+  statusLabel: string;
+};
+
+function statusLabel(status: RoundRow["status"]) {
+  switch (status) {
+    case "COMPLETED":
+      return "완료";
+    case "IN_PROGRESS":
+      return "진행 중";
+    default:
+      return "대기";
+  }
+}
+
+function getProgramStatusMeta(status: RoundRow["status"]) {
+  switch (status) {
+    case "COMPLETED":
+      return { label: "완료", className: "bg-emerald-50 text-emerald-700 border-emerald-200" };
+    case "IN_PROGRESS":
+      return { label: "진행 중", className: "bg-blue-50 text-blue-700 border-blue-200" };
+    default:
+      return { label: "대기", className: "bg-neutral-100 text-neutral-700 border-neutral-200" };
+  }
+}
+
+export function getProgramStatusBadge(status: RoundRow["status"]) {
+  return getProgramStatusMeta(status);
+}
+
+async function fetchDashboardBaseData() {
+  const supabase = await createClient();
+
+  const [roundsResult, companiesResult, usersResult, criteriaResult, evaluationsResult] =
+    await Promise.all([
+      supabase.from("judging_round").select(`id, status, program:program_id ( id, name, start_date, end_date )`),
+      supabase.from("judging_round_company").select(`judging_round_id, company_id, company:company_id ( name )`),
+      supabase.from("judging_round_user").select("judging_round_id, user_id"),
+      supabase.from("evaluation_criteria").select("judging_round_id, id"),
+      supabase.from("evaluation").select("judging_round_id, company_id, user_id, evaluation_criterion_id, feedback"),
+    ]);
+
+  if (roundsResult.error) throw new Error(roundsResult.error.message);
+  if (companiesResult.error) throw new Error(companiesResult.error.message);
+  if (usersResult.error) throw new Error(usersResult.error.message);
+  if (criteriaResult.error) throw new Error(criteriaResult.error.message);
+  if (evaluationsResult.error) throw new Error(evaluationsResult.error.message);
+
+  return {
+    rounds: (roundsResult.data ?? []) as unknown as RoundRow[],
+    companies: (companiesResult.data ?? []) as unknown as CompanyRow[],
+    users: (usersResult.data ?? []) as UserRow[],
+    criteria: (criteriaResult.data ?? []) as CriteriaRow[],
+    evaluations: (evaluationsResult.data ?? []) as EvaluationRow[],
+  };
+}
+
+function buildAggregates() {
+  return fetchDashboardBaseData().then(({ rounds, companies, users, criteria, evaluations }) => {
+    const companiesByRound = new Map<string, CompanyRow[]>();
+    for (const company of companies) {
+      const list = companiesByRound.get(company.judging_round_id) ?? [];
+      list.push(company);
+      companiesByRound.set(company.judging_round_id, list);
+    }
+
+    const usersByRound = new Map<string, Set<string>>();
+    for (const user of users) {
+      const set = usersByRound.get(user.judging_round_id) ?? new Set<string>();
+      set.add(user.user_id);
+      usersByRound.set(user.judging_round_id, set);
+    }
+
+    const criteriaCountByRound = new Map<string, number>();
+    for (const criterion of criteria) {
+      criteriaCountByRound.set(
+        criterion.judging_round_id,
+        (criteriaCountByRound.get(criterion.judging_round_id) ?? 0) + 1
+      );
+    }
+
+    const evalCountByRoundCompany = new Map<string, number>();
+    const judgeSetByRoundCompany = new Map<string, Set<string>>();
+    const feedbackCountByRoundCompany = new Map<string, number>();
+
+    for (const evaluation of evaluations) {
+      const key = `${evaluation.judging_round_id}:${evaluation.company_id}`;
+      evalCountByRoundCompany.set(key, (evalCountByRoundCompany.get(key) ?? 0) + 1);
+
+      if (evaluation.user_id) {
+        const judgeSet = judgeSetByRoundCompany.get(key) ?? new Set<string>();
+        judgeSet.add(evaluation.user_id);
+        judgeSetByRoundCompany.set(key, judgeSet);
+      }
+
+      if (evaluation.feedback && evaluation.feedback.trim().length > 0) {
+        feedbackCountByRoundCompany.set(key, (feedbackCountByRoundCompany.get(key) ?? 0) + 1);
+      }
+    }
+
+    const programRows: ProgramDashboardRow[] = rounds
+      .map((round) => {
+        const roundCompanies = companiesByRound.get(round.id) ?? [];
+        const assignedJudges = usersByRound.get(round.id)?.size ?? 0;
+        const criteriaCount = criteriaCountByRound.get(round.id) ?? 0;
+        const expectedEvaluationCountPerCompany = assignedJudges * criteriaCount;
+
+        let completedCompanies = 0;
+        let feedbackMissingCount = 0;
+
+        for (const company of roundCompanies) {
+          const key = `${round.id}:${company.company_id}`;
+          const evaluationCount = evalCountByRoundCompany.get(key) ?? 0;
+          const judgeCount = judgeSetByRoundCompany.get(key)?.size ?? 0;
+          const feedbackCount = feedbackCountByRoundCompany.get(key) ?? 0;
+
+          const isCompleted =
+            expectedEvaluationCountPerCompany > 0
+              ? evaluationCount >= expectedEvaluationCountPerCompany
+              : judgeCount > 0;
+
+          if (isCompleted) {
+            completedCompanies += 1;
+          }
+
+          const feedbackExpected = assignedJudges > 0 ? assignedJudges : judgeCount;
+          if (judgeCount > 0 && feedbackCount < feedbackExpected) {
+            feedbackMissingCount += 1;
+          }
+        }
+
+        const pendingCompanies = Math.max(roundCompanies.length - completedCompanies, 0);
+        const completionRate = roundCompanies.length === 0 ? 0 : Math.round((completedCompanies / roundCompanies.length) * 100);
+
+        return {
+          judgingRoundId: round.id,
+          programId: round.program?.id ?? 0,
+          programName: round.program?.name ?? "이름 없는 프로그램",
+          status: round.status,
+          totalCompanies: roundCompanies.length,
+          completedCompanies,
+          pendingCompanies,
+          completionRate,
+          feedbackMissingCount,
+        };
+      })
+      .sort((a, b) => {
+        if (b.pendingCompanies !== a.pendingCompanies) return b.pendingCompanies - a.pendingCompanies;
+        return a.programName.localeCompare(b.programName, "ko");
+      });
+
+    const pendingCompaniesRows: PendingCompanyRow[] = [];
+
+    for (const round of rounds) {
+      const roundCompanies = companiesByRound.get(round.id) ?? [];
+      const assignedJudges = usersByRound.get(round.id)?.size ?? 0;
+      const criteriaCount = criteriaCountByRound.get(round.id) ?? 0;
+      const expectedEvaluationCountPerCompany = assignedJudges * criteriaCount;
+
+      for (const company of roundCompanies) {
+        const key = `${round.id}:${company.company_id}`;
+        const evaluationCount = evalCountByRoundCompany.get(key) ?? 0;
+        const completedJudges = judgeSetByRoundCompany.get(key)?.size ?? 0;
+        const feedbackCount = feedbackCountByRoundCompany.get(key) ?? 0;
+        const feedbackExpected = assignedJudges > 0 ? assignedJudges : completedJudges;
+        const isComplete =
+          expectedEvaluationCountPerCompany > 0
+            ? evaluationCount >= expectedEvaluationCountPerCompany
+            : completedJudges > 0;
+        const feedbackMissing = completedJudges > 0 && feedbackCount < feedbackExpected;
+
+        if (!isComplete || feedbackMissing) {
+          const completionRate = assignedJudges === 0 ? 0 : Math.round((completedJudges / assignedJudges) * 100);
+          pendingCompaniesRows.push({
+            judgingRoundId: round.id,
+            programName: round.program?.name ?? "이름 없는 프로그램",
+            companyId: company.company_id,
+            companyName: company.company?.name ?? "이름 없는 기업",
+            assignedJudges,
+            completedJudges,
+            completionRate,
+            feedbackMissing,
+            statusLabel: !isComplete
+              ? completedJudges === 0
+                ? "미평가"
+                : "진행 중"
+              : "피드백 누락",
+          });
+        }
+      }
+    }
+
+    pendingCompaniesRows.sort((a, b) => {
+      if (a.feedbackMissing !== b.feedbackMissing) return Number(b.feedbackMissing) - Number(a.feedbackMissing);
+      if (a.completionRate !== b.completionRate) return a.completionRate - b.completionRate;
+      return a.programName.localeCompare(b.programName, "ko");
+    });
+
+    const overview: DashboardOverview = {
+      inProgressPrograms: programRows.filter((row) => row.status === "IN_PROGRESS").length,
+      totalCompanies: programRows.reduce((sum, row) => sum + row.totalCompanies, 0),
+      completedCompanies: programRows.reduce((sum, row) => sum + row.completedCompanies, 0),
+      pendingCompanies: programRows.reduce((sum, row) => sum + row.pendingCompanies, 0),
+      feedbackMissingCount: programRows.reduce((sum, row) => sum + row.feedbackMissingCount, 0),
+    };
+
+    return { overview, programRows, pendingCompaniesRows };
+  });
+}
+
+export async function getDashboardOverview() {
+  return (await buildAggregates()).overview;
+}
+
+export async function getProgramDashboardRows() {
+  return (await buildAggregates()).programRows;
+}
+
+export async function getPendingCompanyRows() {
+  return (await buildAggregates()).pendingCompaniesRows;
+}
+
+export { statusLabel };

--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -1,3 +1,37 @@
+import { Suspense } from "react";
+import { DashboardOverview } from "./_components/dashboard-overview";
+import { ProgramStatusTable } from "./_components/program-status-table";
+import { PendingCompaniesTable } from "./_components/pending-companies-table";
+import {
+  DashboardCardsSkeleton,
+  DashboardTableSkeleton,
+} from "./_components/dashboard-section-skeleton";
+
 export default function Page() {
-  return <div>sdf</div>;
+  return (
+    <div className="flex min-h-screen w-full flex-col gap-6 bg-neutral-50 p-4 sm:p-6 lg:p-10">
+      <section className="space-y-2">
+        <p className="text-sm font-medium text-neutral-500">Admin Dashboard</p>
+        <h1 className="text-2xl font-semibold tracking-tight text-neutral-950 sm:text-3xl">
+          심사 운영 대시보드
+        </h1>
+        <p className="max-w-3xl text-sm leading-6 text-neutral-600 sm:text-base">
+          느린 데이터 로딩 환경에서도 운영자가 먼저 필요한 정보를 빠르게 확인할 수 있도록,
+          요약 카드와 프로그램 현황, 조치가 필요한 기업 목록을 섹션 단위로 나눠 점진적으로 보여줍니다.
+        </p>
+      </section>
+
+      <Suspense fallback={<DashboardCardsSkeleton />}>
+        <DashboardOverview />
+      </Suspense>
+
+      <Suspense fallback={<DashboardTableSkeleton rows={6} />}>
+        <ProgramStatusTable />
+      </Suspense>
+
+      <Suspense fallback={<DashboardTableSkeleton rows={5} />}>
+        <PendingCompaniesTable />
+      </Suspense>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- add an admin-facing judging operations dashboard for Startup Partners
- surface operator-first metrics such as blocked programs, pending companies, missing feedback, and overall completion rate
- rework the program table into an action-oriented operations view with clearer problem-first sorting and attention status
- keep progressive rendering with sectioned Suspense boundaries and skeleton loading UI for slow Vercel + Supabase environments

## Why
This change strengthens the product as an operator tool and makes operational bottlenecks easier to identify quickly, especially in a low-cost environment where loading all data at once can feel slow.

## Notes
- lint: passed
- type-check: passed