### PR TITLE
feat: 한 기업에 여러 멘토 배정(N:M) 지원

### DIFF
--- a/src/actions/mentoring-action.ts
+++ b/src/actions/mentoring-action.ts
@@ -184,6 +184,25 @@ function takeFirstRelation<T>(value: unknown): T | null {
   return (value as T | null | undefined) ?? null;
 }
 
+// mentoring_company_mentor 조인 결과(배정 멘토 목록)를 매핑한다.
+function mapAssignmentMentors(rawMentors: unknown): MentoringAssignmentMentor[] {
+  return (Array.isArray(rawMentors) ? rawMentors : []).map((link) => {
+    const mentor = takeFirstRelation<{
+      id: string;
+      username: string;
+      affiliation: string | null;
+      position: string | null;
+    }>((link as { mentor: unknown }).mentor);
+    return {
+      mentor_id: mentor?.id ?? "",
+      mentor_name: mentor?.username ?? null,
+      mentor_affiliation: mentor?.affiliation ?? null,
+      mentor_position: mentor?.position ?? null,
+      claimed_at: (link as { claimed_at: string | null }).claimed_at ?? null,
+    };
+  });
+}
+
 function isWebpUpload(fileName: string, contentType?: string) {
   const normalizedType = contentType?.toLowerCase();
   const normalizedName = fileName.toLowerCase();
@@ -544,24 +563,7 @@ export async function getMentoringByProgramId(
         representative_name: string | null;
       }>(item.company as unknown);
 
-      const mentors: MentoringAssignmentMentor[] = (
-        Array.isArray(item.mentors) ? item.mentors : []
-      ).map((link) => {
-        const mentor = takeFirstRelation<{
-          id: string;
-          username: string;
-          affiliation: string | null;
-          position: string | null;
-        }>((link as { mentor: unknown }).mentor);
-        return {
-          mentor_id: mentor?.id ?? "",
-          mentor_name: mentor?.username ?? null,
-          mentor_affiliation: mentor?.affiliation ?? null,
-          mentor_position: mentor?.position ?? null,
-          claimed_at:
-            (link as { claimed_at: string | null }).claimed_at ?? null,
-        };
-      });
+      const mentors = mapAssignmentMentors(item.mentors);
 
       return {
         company_id: item.company_id,

--- a/src/actions/mentoring-action.ts
+++ b/src/actions/mentoring-action.ts
@@ -29,18 +29,21 @@ export interface MentoringProgramSummary {
   end_date: string | null;
 }
 
+export interface MentoringAssignmentMentor {
+  mentor_id: string;
+  mentor_name: string | null;
+  mentor_affiliation: string | null;
+  mentor_position: string | null;
+  claimed_at: string | null;
+}
+
 export interface MentoringAssignment {
   company_id: number;
   company_name: string;
   company_description: string | null;
   representative_name: string | null;
-  mentor_id: string | null;
-  mentor_name: string | null;
-  mentor_affiliation: string | null;
-  mentor_position: string | null;
-  claimed_at: string | null;
+  mentors: MentoringAssignmentMentor[];
   is_mine: boolean;
-  can_claim: boolean;
   session_count: number;
   last_mentored_at: string | null;
 }
@@ -296,15 +299,15 @@ async function getMentoringBase(
 function buildAssignmentStats(
   assignments: Array<{
     company_id: number;
-    mentor_id: string | null;
+    mentors: { mentor_id: string }[];
   }>,
   viewerId: string
 ) {
   const assignedCompanyCount = assignments.filter(
-    (item) => item.mentor_id !== null
+    (item) => item.mentors.length > 0
   ).length;
-  const myCompanyCount = assignments.filter(
-    (item) => item.mentor_id === viewerId
+  const myCompanyCount = assignments.filter((item) =>
+    item.mentors.some((m) => m.mentor_id === viewerId)
   ).length;
 
   return { assignedCompanyCount, myCompanyCount };
@@ -436,19 +439,20 @@ export async function getMentoringByProgramId(
       .select(
         `
           company_id,
-          mentor_id,
-          claimed_at,
           company:company_id (
             id,
             name,
             description,
             representative_name
           ),
-          mentor:mentor_id (
-            id,
-            username,
-            affiliation,
-            position
+          mentors:mentoring_company_mentor (
+            claimed_at,
+            mentor:mentor_id (
+              id,
+              username,
+              affiliation,
+              position
+            )
           )
         `
       )
@@ -533,12 +537,6 @@ export async function getMentoringByProgramId(
   const mentoringCompanies: MentoringAssignment[] = (companies ?? []).map(
     (item) => {
       const stats = sessionStats.get(item.company_id);
-      const mentor = takeFirstRelation<{
-        id: string;
-        username: string;
-        affiliation: string | null;
-        position: string | null;
-      }>(item.mentor as unknown);
       const company = takeFirstRelation<{
         id: number;
         name: string;
@@ -546,18 +544,32 @@ export async function getMentoringByProgramId(
         representative_name: string | null;
       }>(item.company as unknown);
 
+      const mentors: MentoringAssignmentMentor[] = (
+        Array.isArray(item.mentors) ? item.mentors : []
+      ).map((link) => {
+        const mentor = takeFirstRelation<{
+          id: string;
+          username: string;
+          affiliation: string | null;
+          position: string | null;
+        }>((link as { mentor: unknown }).mentor);
+        return {
+          mentor_id: mentor?.id ?? "",
+          mentor_name: mentor?.username ?? null,
+          mentor_affiliation: mentor?.affiliation ?? null,
+          mentor_position: mentor?.position ?? null,
+          claimed_at:
+            (link as { claimed_at: string | null }).claimed_at ?? null,
+        };
+      });
+
       return {
         company_id: item.company_id,
         company_name: company?.name ?? "",
         company_description: company?.description ?? null,
         representative_name: company?.representative_name ?? null,
-        mentor_id: item.mentor_id,
-        mentor_name: mentor?.username ?? null,
-        mentor_affiliation: mentor?.affiliation ?? null,
-        mentor_position: mentor?.position ?? null,
-        claimed_at: item.claimed_at,
-        is_mine: false,
-        can_claim: false,
+        mentors,
+        is_mine: mentors.some((m) => m.mentor_id === context.viewer.id),
         session_count: stats?.count ?? 0,
         last_mentored_at: stats?.lastMentoredAt ?? null,
       };
@@ -566,11 +578,12 @@ export async function getMentoringByProgramId(
 
   const assignedCounts = new Map<string, number>();
   mentoringCompanies.forEach((company) => {
-    if (!company.mentor_id) return;
-    assignedCounts.set(
-      company.mentor_id,
-      (assignedCounts.get(company.mentor_id) ?? 0) + 1
-    );
+    company.mentors.forEach((mentor) => {
+      assignedCounts.set(
+        mentor.mentor_id,
+        (assignedCounts.get(mentor.mentor_id) ?? 0) + 1
+      );
+    });
   });
 
   const mentoringMentors = (mentors ?? []).map((item) => {
@@ -686,7 +699,9 @@ export async function getAllMentorings(
       ),
       companies:mentoring_company (
         company_id,
-        mentor_id
+        mentors:mentoring_company_mentor (
+          mentor_id
+        )
       ),
       sessions:mentoring_session (
         id,
@@ -714,7 +729,9 @@ export async function getAllMentorings(
         ),
         companies:mentoring_company (
           company_id,
-          mentor_id
+          mentors:mentoring_company_mentor (
+            mentor_id
+          )
         ),
         sessions:mentoring_session (
           id,
@@ -764,7 +781,10 @@ export async function getAllMentorings(
       created_at: string;
       report_logo_path: string | null;
       program: Partial<MentoringProgramSummary> | null;
-      companies: Array<{ company_id: number; mentor_id: string | null }>;
+      companies: Array<{
+        company_id: number;
+        mentors: { mentor_id: string }[];
+      }>;
       sessions: Array<{ id: number; mentored_at: string }>;
     }>
   ).map(async (item) => {
@@ -862,18 +882,20 @@ export async function getMentoringDetail(
       .select(
         `
           company_id,
-          mentor_id,
-          claimed_at,
           company:company_id (
             id,
             name,
             description,
             representative_name
           ),
-          mentor:mentor_id (
-            id,
-            username,
-            affiliation
+          mentors:mentoring_company_mentor (
+            claimed_at,
+            mentor:mentor_id (
+              id,
+              username,
+              affiliation,
+              position
+            )
           )
         `
       )
@@ -932,12 +954,6 @@ export async function getMentoringDetail(
   const isAdminView = context.isAdmin && !isParticipant;
 
   const allAssignments = (assignments ?? []).map((item) => {
-    const mentor = takeFirstRelation<{
-      id: string;
-      username: string;
-      affiliation: string | null;
-      position: string | null;
-    }>(item.mentor as unknown);
     const company = takeFirstRelation<{
       id: number;
       name: string;
@@ -945,24 +961,37 @@ export async function getMentoringDetail(
       representative_name: string | null;
     }>(item.company as unknown);
 
+    const mentors: MentoringAssignmentMentor[] = (
+      Array.isArray(item.mentors) ? item.mentors : []
+    ).map((link) => {
+      const mentor = takeFirstRelation<{
+        id: string;
+        username: string;
+        affiliation: string | null;
+        position: string | null;
+      }>((link as { mentor: unknown }).mentor);
+      return {
+        mentor_id: mentor?.id ?? "",
+        mentor_name: mentor?.username ?? null,
+        mentor_affiliation: mentor?.affiliation ?? null,
+        mentor_position: mentor?.position ?? null,
+        claimed_at: (link as { claimed_at: string | null }).claimed_at ?? null,
+      };
+    });
+
     return {
       company_id: item.company_id,
       company_name: company?.name ?? "",
       company_description: company?.description ?? null,
       representative_name: company?.representative_name ?? null,
-      mentor_id: item.mentor_id,
-      mentor_name: mentor?.username ?? null,
-      mentor_affiliation: mentor?.affiliation ?? null,
-      mentor_position: mentor?.position ?? null,
-      claimed_at: item.claimed_at,
+      mentors,
     };
   });
 
   const visibleAssignments = isAdminView
     ? allAssignments
-    : allAssignments.filter(
-        (item) =>
-          item.mentor_id === context.viewer.id || item.mentor_id === null
+    : allAssignments.filter((item) =>
+        item.mentors.some((m) => m.mentor_id === context.viewer.id)
       );
   const visibleCompanyIds = new Set(
     visibleAssignments.map((item) => item.company_id)
@@ -997,12 +1026,7 @@ export async function getMentoringDetail(
       const stats = sessionStats.get(item.company_id);
       return {
         ...item,
-        is_mine: item.mentor_id === context.viewer.id,
-        can_claim:
-          !isAdminView &&
-          base.status !== "COMPLETED" &&
-          item.mentor_id === null &&
-          availableMentorIds.has(context.viewer.id),
+        is_mine: item.mentors.some((m) => m.mentor_id === context.viewer.id),
         session_count: stats?.count ?? 0,
         last_mentored_at: stats?.lastMentoredAt ?? null,
       };
@@ -1261,9 +1285,12 @@ export async function updateMentoringUsers(args: {
         { count: sessionCount, error: sessionError },
       ] = await Promise.all([
         context.supabase
-          .from("mentoring_company")
-          .select("id", { count: "exact", head: true })
-          .eq("mentoring_id", args.mentoringId)
+          .from("mentoring_company_mentor")
+          .select("id, mentoring_company!inner(mentoring_id)", {
+            count: "exact",
+            head: true,
+          })
+          .eq("mentoring_company.mentoring_id", args.mentoringId)
           .in("mentor_id", toRemove),
         context.supabase
           .from("mentoring_session")
@@ -1312,92 +1339,93 @@ export async function updateMentoringUsers(args: {
   });
 }
 
-export async function assignMentoringCompanyByAdmin(args: {
+export async function setMentoringCompanyMentors(args: {
   mentoringId: string;
   companyId: number;
-  mentorId: string | null;
+  mentorIds: string[];
 }) {
   return withActionResult(async () => {
     const context = await assertAdmin();
+    const mentorIds = Array.from(new Set(args.mentorIds));
 
-    if (args.mentorId) {
-      const { data: mentor, error: mentorError } = await context.supabase
+    // 대상 기업의 mentoring_company 행 확인
+    const { data: companyRow, error: companyError } = await context.supabase
+      .from("mentoring_company")
+      .select("id")
+      .eq("mentoring_id", args.mentoringId)
+      .eq("company_id", args.companyId)
+      .maybeSingle();
+
+    if (companyError) raiseActionError(companyError);
+    if (!companyRow) {
+      throw new Error("멘토링 대상 기업을 찾을 수 없습니다.");
+    }
+
+    // 멘토는 모두 해당 멘토링 참여자여야 함
+    if (mentorIds.length > 0) {
+      const { data: enrolled, error: enrolledError } = await context.supabase
         .from("mentoring_user")
-        .select("id")
+        .select("user_id")
         .eq("mentoring_id", args.mentoringId)
-        .eq("user_id", args.mentorId)
-        .maybeSingle();
+        .in("user_id", mentorIds);
 
-      if (mentorError) {
-        raiseActionError(mentorError);
-      }
+      if (enrolledError) raiseActionError(enrolledError);
 
-      if (!mentor) {
+      const enrolledIds = new Set((enrolled ?? []).map((m) => m.user_id));
+      if (mentorIds.some((id) => !enrolledIds.has(id))) {
         throw new Error("멘토링 참여 멘토만 배정할 수 있습니다.");
       }
     }
 
-    const { data, error } = await context.supabase
-      .from("mentoring_company")
-      .update({
-        mentor_id: args.mentorId,
-        claimed_at: args.mentorId ? new Date().toISOString() : null,
-      })
-      .eq("mentoring_id", args.mentoringId)
-      .eq("company_id", args.companyId)
-      .select("id")
-      .maybeSingle();
+    // 현재 배정과 diff
+    const { data: current, error: currentError } = await context.supabase
+      .from("mentoring_company_mentor")
+      .select("mentor_id")
+      .eq("mentoring_company_id", companyRow.id);
 
-    if (error) {
-      raiseActionError(error);
+    if (currentError) raiseActionError(currentError);
+
+    const currentIds = new Set((current ?? []).map((m) => m.mentor_id));
+    const nextIds = new Set(mentorIds);
+    const toAdd = mentorIds.filter((id) => !currentIds.has(id));
+    const toRemove = Array.from(currentIds).filter((id) => !nextIds.has(id));
+
+    // 세션을 작성한 멘토는 배정 해제 불가
+    if (toRemove.length > 0) {
+      const { count, error: sessionError } = await context.supabase
+        .from("mentoring_session")
+        .select("id", { count: "exact", head: true })
+        .eq("mentoring_id", args.mentoringId)
+        .eq("company_id", args.companyId)
+        .in("mentor_id", toRemove);
+
+      if (sessionError) raiseActionError(sessionError);
+      if ((count ?? 0) > 0) {
+        throw new Error("멘토링 기록이 있는 멘토는 배정 해제할 수 없습니다.");
+      }
+
+      const { error: deleteError } = await context.supabase
+        .from("mentoring_company_mentor")
+        .delete()
+        .eq("mentoring_company_id", companyRow.id)
+        .in("mentor_id", toRemove);
+
+      if (deleteError) raiseActionError(deleteError);
     }
 
-    if (!data) {
-      throw new Error("멘토링 대상 기업을 찾을 수 없습니다.");
-    }
+    if (toAdd.length > 0) {
+      const { error: insertError } = await context.supabase
+        .from("mentoring_company_mentor")
+        .insert(
+          toAdd.map((mentorId) => ({
+            mentoring_company_id: companyRow.id,
+            mentor_id: mentorId,
+            claimed_at: new Date().toISOString(),
+            created_at: new Date().toISOString(),
+          }))
+        );
 
-    return undefined;
-  });
-}
-
-export async function claimMentoringCompany(args: {
-  mentoringId: string;
-  companyId: number;
-}) {
-  return withActionResult(async () => {
-    const context = await getViewerContext();
-
-    await ensureMentoringParticipant(context, args.mentoringId);
-
-    const { data: mentoringStatus, error: mentoringStatusError } =
-      await context.supabase
-        .from("mentoring")
-        .select("status")
-        .eq("id", args.mentoringId)
-        .single();
-    if (mentoringStatusError) raiseActionError(mentoringStatusError);
-    if (mentoringStatus?.status === "COMPLETED") {
-      throw new Error("종료된 멘토링에서는 기업을 선택할 수 없습니다.");
-    }
-
-    const { data, error } = await context.supabase
-      .from("mentoring_company")
-      .update({
-        mentor_id: context.viewer.id,
-        claimed_at: new Date().toISOString(),
-      })
-      .eq("mentoring_id", args.mentoringId)
-      .eq("company_id", args.companyId)
-      .is("mentor_id", null)
-      .select("id")
-      .maybeSingle();
-
-    if (error) {
-      raiseActionError(error);
-    }
-
-    if (!data) {
-      throw new Error("이미 다른 멘토가 선택한 기업입니다.");
+      if (insertError) raiseActionError(insertError);
     }
 
     return undefined;
@@ -1494,18 +1522,29 @@ export async function upsertMentoringSession(args: {
       throw new Error("종료된 멘토링에서는 기록을 수정할 수 없습니다.");
     }
 
-    const { data: assignment, error: assignmentError } = await context.supabase
+    const { data: companyRow, error: companyError } = await context.supabase
       .from("mentoring_company")
-      .select("mentor_id")
+      .select("id")
       .eq("mentoring_id", args.mentoringId)
       .eq("company_id", args.companyId)
       .maybeSingle();
 
-    if (assignmentError) {
-      raiseActionError(assignmentError);
+    if (companyError) raiseActionError(companyError);
+    if (!companyRow) {
+      throw new Error(
+        "현재 담당 기업에 대해서만 멘토링 기록을 작성할 수 있습니다."
+      );
     }
 
-    if (!assignment || assignment.mentor_id !== context.viewer.id) {
+    const { data: assignment, error: assignmentError } = await context.supabase
+      .from("mentoring_company_mentor")
+      .select("id")
+      .eq("mentoring_company_id", companyRow.id)
+      .eq("mentor_id", context.viewer.id)
+      .maybeSingle();
+
+    if (assignmentError) raiseActionError(assignmentError);
+    if (!assignment) {
       throw new Error(
         "현재 담당 기업에 대해서만 멘토링 기록을 작성할 수 있습니다."
       );

--- a/src/app/(admin)/admin/program/[programId]/_components/MentoringEditForm.tsx
+++ b/src/app/(admin)/admin/program/[programId]/_components/MentoringEditForm.tsx
@@ -8,21 +8,15 @@ import { executeAction, getErrorMessage } from "@/lib/action";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { LoadingButton } from "@/components/ui/loading-button";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { Checkbox } from "@/components/ui/checkbox";
 import { mentoringQueries } from "@/queries";
 import type {
   MentoringManagementSummary,
   MentoringStatus,
 } from "@/actions/mentoring-action";
 import {
-  assignMentoringCompanyByAdmin,
   createMentoringReportLogoUploadUrl,
+  setMentoringCompanyMentors,
   updateMentoringCompanies,
   updateMentoringReportLogo,
   updateMentoringUsers,
@@ -194,13 +188,13 @@ export default function MentoringEditForm({
   const assignmentMutation = useMutation({
     mutationFn: async (payload: {
       companyId: number;
-      mentorId: string | null;
+      mentorIds: string[];
     }) =>
       executeAction(
-        assignMentoringCompanyByAdmin({
+        setMentoringCompanyMentors({
           mentoringId,
           companyId: payload.companyId,
-          mentorId: payload.mentorId,
+          mentorIds: payload.mentorIds,
         })
       ),
     onSuccess: () => {
@@ -211,6 +205,18 @@ export default function MentoringEditForm({
       toast.error(getErrorMessage(error, "멘토 배정을 수정하지 못했습니다."));
     },
   });
+
+  const toggleCompanyMentor = (
+    company: (typeof data.companies)[number],
+    mentorId: string,
+    checked: boolean
+  ) => {
+    const currentIds = company.mentors.map((m) => m.mentor_id);
+    const nextIds = checked
+      ? Array.from(new Set([...currentIds, mentorId]))
+      : currentIds.filter((id) => id !== mentorId);
+    assignmentMutation.mutate({ companyId: company.company_id, mentorIds: nextIds });
+  };
 
   const clearLogoDraft = () => {
     if (logoObjectUrlRef.current) {
@@ -286,7 +292,7 @@ export default function MentoringEditForm({
   });
 
   const assignedCompanyCount = useMemo(
-    () => data.companies.filter((company) => company.mentor_id).length,
+    () => data.companies.filter((company) => company.mentors.length > 0).length,
     [data.companies]
   );
 
@@ -513,8 +519,12 @@ export default function MentoringEditForm({
                       </div>
                     </div>
                     <span className="shrink-0 text-xs text-neutral-500">
-                      {company.mentor_name ? (
-                        <span className="font-medium text-neutral-700">{company.mentor_name}</span>
+                      {company.mentors.length > 0 ? (
+                        <span className="font-medium text-neutral-700">
+                          {company.mentors.length === 1
+                            ? company.mentors[0].mentor_name
+                            : `${company.mentors[0].mentor_name} 외 ${company.mentors.length - 1}명`}
+                        </span>
                       ) : (
                         <span className="text-neutral-400">미배정</span>
                       )}
@@ -534,38 +544,42 @@ export default function MentoringEditForm({
                       </p>
                     </div>
                     <div className="rounded-xl border border-neutral-200 bg-white p-3">
-                      <p className="text-xs font-medium tracking-wide text-neutral-500 uppercase">담당 멘토 변경</p>
-                      {company.mentor_name && (
-                        <p className="mt-1 text-sm font-medium text-neutral-900">{company.mentor_name}</p>
+                      <p className="text-xs font-medium tracking-wide text-neutral-500 uppercase">담당 멘토</p>
+                      {data.mentors.length === 0 ? (
+                        <p className="mt-2 text-sm text-neutral-400">
+                          참여 멘토가 없습니다.
+                        </p>
+                      ) : (
+                        <div className="mt-2 space-y-2">
+                          {data.mentors.map((mentor) => {
+                            const checked = company.mentors.some(
+                              (m) => m.mentor_id === mentor.id
+                            );
+                            return (
+                              <label
+                                key={mentor.id}
+                                className="flex items-center gap-2 text-sm text-neutral-800"
+                              >
+                                <Checkbox
+                                  checked={checked}
+                                  disabled={assignmentMutation.isPending}
+                                  onCheckedChange={(value) =>
+                                    toggleCompanyMentor(
+                                      company,
+                                      mentor.id,
+                                      value === true
+                                    )
+                                  }
+                                />
+                                <span>
+                                  {mentor.name}
+                                  {mentor.affiliation ? ` · ${mentor.affiliation}` : ""}
+                                </span>
+                              </label>
+                            );
+                          })}
+                        </div>
                       )}
-                      <div className="mt-2">
-                        <Select
-                          value={company.mentor_id ?? "__unassigned"}
-                          onValueChange={(value) =>
-                            assignmentMutation.mutate({
-                              companyId: company.company_id,
-                              mentorId: value === "__unassigned" ? null : value,
-                            })
-                          }
-                          disabled={
-                            assignmentMutation.isPending ||
-                            data.mentors.length === 0
-                          }
-                        >
-                          <SelectTrigger className="bg-white text-sm">
-                            <SelectValue placeholder="멘토 선택" />
-                          </SelectTrigger>
-                          <SelectContent>
-                            <SelectItem value="__unassigned">미배정</SelectItem>
-                            {data.mentors.map((mentor) => (
-                              <SelectItem key={mentor.id} value={mentor.id}>
-                                {mentor.name}
-                                {mentor.affiliation ? ` · ${mentor.affiliation}` : ""}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      </div>
                     </div>
                   </div>
                 </AccordionContent>

--- a/src/app/(home)/mentoring/[mentoringId]/page.tsx
+++ b/src/app/(home)/mentoring/[mentoringId]/page.tsx
@@ -7,7 +7,6 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { executeAction, getErrorMessage } from "@/lib/action";
 import {
-  claimMentoringCompany,
   createMentoringSessionPhotoUploadUrl,
   deleteMentoringSession,
   getMentoringSessionReportAssets,
@@ -145,11 +144,6 @@ export default function MentoringDetailPage() {
     () => mentoring?.assignments.filter((item) => item.is_mine) ?? [],
     [mentoring]
   );
-  const availableAssignments = useMemo(
-    () => mentoring?.assignments.filter((item) => item.can_claim) ?? [],
-    [mentoring]
-  );
-
   const activeCompanyId = useMemo(() => {
     if (!mentoring || mentoring.assignments.length === 0) {
       return null;
@@ -176,17 +170,10 @@ export default function MentoringDetailPage() {
 
     return (
       myAssignments[0]?.company_id ??
-      availableAssignments[0]?.company_id ??
       mentoring.assignments[0]?.company_id ??
       null
     );
-  }, [
-    availableAssignments,
-    mentoring,
-    myAssignments,
-    requestedCompanyId,
-    selectedCompanyId,
-  ]);
+  }, [mentoring, myAssignments, requestedCompanyId, selectedCompanyId]);
 
   const selectedCompany = useMemo(
     () =>
@@ -270,18 +257,6 @@ export default function MentoringDetailPage() {
   }, [companySessions.length, selectedCompany, sessionCarouselApi]);
 
   useEffect(() => () => clearEditorPhotos(), []);
-
-  const claimMutation = useMutation({
-    mutationFn: async (companyId: number) =>
-      executeAction(claimMentoringCompany({ mentoringId, companyId })),
-    onSuccess: () => {
-      toast.success("기업을 선택했습니다.");
-      queryClient.invalidateQueries({ queryKey: mentoringQueries.all() });
-    },
-    onError: (mutationError: unknown) => {
-      toast.error(getErrorMessage(mutationError, "기업 선택에 실패했습니다."));
-    },
-  });
 
   const saveMutation = useMutation({
     mutationFn: async () => {
@@ -503,10 +478,12 @@ export default function MentoringDetailPage() {
           representativeName={selectedCompany.representative_name}
           mentorName={session.mentor_name}
           mentorAffiliation={
-            session.mentor_affiliation ?? selectedCompany.mentor_affiliation
+            session.mentor_affiliation ??
+            (selectedCompany.mentors[0]?.mentor_affiliation ?? null)
           }
           mentorPosition={
-            session.mentor_position ?? selectedCompany.mentor_position
+            session.mentor_position ??
+            (selectedCompany.mentors[0]?.mentor_position ?? null)
           }
           mentorSignatureUrl={assets.mentorSignatureUrl}
           logoUrl={assets.logoUrl}
@@ -529,6 +506,17 @@ export default function MentoringDetailPage() {
     } finally {
       setDownloadingSessionId(null);
     }
+  };
+
+  const formatMentorNames = (
+    mentors: { mentor_name: string | null }[]
+  ): string => {
+    if (mentors.length === 0) return "미배정";
+    const names = mentors.map((m) => m.mentor_name).filter(Boolean) as string[];
+    if (names.length === 0) return "미배정";
+    return names.length === 1
+      ? `담당 ${names[0]}`
+      : `담당 ${names[0]} 외 ${names.length - 1}명`;
   };
 
   if (isLoading || !mentoring) {
@@ -630,66 +618,13 @@ export default function MentoringDetailPage() {
                             : "text-neutral-500"
                         }`}
                       >
-                        {company.mentor_name
-                          ? `담당 ${company.mentor_name}`
-                          : "미배정"}
+                        {formatMentorNames(company.mentors)}
                       </p>
                     </button>
                   ))
                 )}
               </div>
             </section>
-
-            {!mentoring.isAdminView && (
-              <section className="rounded-2xl border bg-white p-5 shadow-sm">
-                <div className="flex items-center gap-2">
-                  <UserRound className="h-4 w-4 text-neutral-500" />
-                  <h2 className="text-sm font-semibold text-neutral-900">
-                    배정 가능한 기업
-                  </h2>
-                </div>
-                <div className="mt-4 space-y-2">
-                  {availableAssignments.length === 0 ? (
-                    <div className="rounded-xl border border-dashed border-neutral-200 px-4 py-6 text-center text-sm text-neutral-400">
-                      선택 가능한 기업이 없습니다.
-                    </div>
-                  ) : (
-                    availableAssignments.map((company) => (
-                      <div
-                        key={company.company_id}
-                        className="rounded-xl border border-neutral-200 bg-neutral-50 p-4"
-                      >
-                        <div className="flex items-start justify-between gap-2">
-                          <div>
-                            <p className="font-medium text-neutral-900">
-                              {company.company_name}
-                            </p>
-                            <p className="mt-1 text-xs text-neutral-500">
-                              대표자 {company.representative_name || "-"}
-                            </p>
-                          </div>
-                          <Badge variant="outline">미배정</Badge>
-                        </div>
-                        <Button
-                          type="button"
-                          size="sm"
-                          className="mt-3 w-full gap-1.5"
-                          disabled={
-                            claimMutation.isPending ||
-                            mentoring.status === "COMPLETED"
-                          }
-                          onClick={() =>
-                            claimMutation.mutate(company.company_id)
-                          }
-                        >
-                          <Plus className="h-4 w-4" />이 기업 선택하기
-                        </Button>
-                      </div>
-                    ))
-                  )}
-                </div>
-              </section>
-            )}
           </aside>
 
           <section className="min-w-0 space-y-4">
@@ -714,9 +649,7 @@ export default function MentoringDetailPage() {
                         대표자 {selectedCompany.representative_name || "-"}
                       </Badge>
                       <Badge variant="outline">
-                        {selectedCompany.mentor_name
-                          ? `담당 ${selectedCompany.mentor_name}`
-                          : "미배정"}
+                        {formatMentorNames(selectedCompany.mentors)}
                       </Badge>
                     </div>
                   </div>
@@ -1194,35 +1127,6 @@ export default function MentoringDetailPage() {
                       )}
                     </div>
                   )}
-
-                  {!mentoring.isAdminView &&
-                    selectedCompany &&
-                    !selectedCompany.is_mine &&
-                    selectedCompany.can_claim && (
-                      <div className="rounded-2xl border bg-white p-5 shadow-sm">
-                        <div className="flex items-center justify-between gap-3">
-                          <div>
-                            <h3 className="text-lg font-semibold text-neutral-950">
-                              먼저 기업을 선택해주세요
-                            </h3>
-                            <p className="mt-1 text-sm text-neutral-600">
-                              이 기업은 아직 담당 멘토가 없습니다. 선택한 뒤
-                              멘토링 기록을 작성할 수 있습니다.
-                            </p>
-                          </div>
-                        </div>
-                        <LoadingButton
-                          type="button"
-                          className="mt-4 w-full gap-2"
-                          loading={claimMutation.isPending}
-                          onClick={() =>
-                            claimMutation.mutate(selectedCompany.company_id)
-                          }
-                        >
-                          <Plus className="h-4 w-4" />이 기업 선택하기
-                        </LoadingButton>
-                      </div>
-                    )}
 
                   {mentoring.isAdminView && (
                     <div className="rounded-2xl border bg-white p-5 shadow-sm">

--- a/src/app/(home)/mentoring/[mentoringId]/page.tsx
+++ b/src/app/(home)/mentoring/[mentoringId]/page.tsx
@@ -479,11 +479,17 @@ export default function MentoringDetailPage() {
           mentorName={session.mentor_name}
           mentorAffiliation={
             session.mentor_affiliation ??
-            (selectedCompany.mentors[0]?.mentor_affiliation ?? null)
+            (selectedCompany.mentors.find(
+              (m) => m.mentor_id === session.mentor_id
+            )?.mentor_affiliation ??
+              null)
           }
           mentorPosition={
             session.mentor_position ??
-            (selectedCompany.mentors[0]?.mentor_position ?? null)
+            (selectedCompany.mentors.find(
+              (m) => m.mentor_id === session.mentor_id
+            )?.mentor_position ??
+              null)
           }
           mentorSignatureUrl={assets.mentorSignatureUrl}
           logoUrl={assets.logoUrl}

--- a/supabase/migrations/20260601000000_multi_mentor_per_company.sql
+++ b/supabase/migrations/20260601000000_multi_mentor_per_company.sql
@@ -1,0 +1,32 @@
+-- 기업↔멘토 배정을 N:M으로 전환한다.
+-- mentoring_company 의 단일 mentor_id/claimed_at 컬럼을 제거하고,
+-- 배정 전용 조인 테이블 mentoring_company_mentor 로 분리한다.
+
+CREATE TABLE IF NOT EXISTS public.mentoring_company_mentor (
+  id bigserial PRIMARY KEY,
+  mentoring_company_id bigint NOT NULL
+    REFERENCES public.mentoring_company(id) ON DELETE CASCADE,
+  mentor_id uuid NOT NULL
+    REFERENCES public."user"(id) ON DELETE CASCADE,
+  claimed_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT mentoring_company_mentor_unique UNIQUE (mentoring_company_id, mentor_id)
+);
+
+CREATE INDEX IF NOT EXISTS mentoring_company_mentor_mentor_id_idx
+  ON public.mentoring_company_mentor (mentor_id);
+CREATE INDEX IF NOT EXISTS mentoring_company_mentor_company_idx
+  ON public.mentoring_company_mentor (mentoring_company_id);
+
+-- 기존 단일 배정 데이터 이관
+INSERT INTO public.mentoring_company_mentor
+  (mentoring_company_id, mentor_id, claimed_at, created_at)
+SELECT id, mentor_id, claimed_at, created_at
+FROM public.mentoring_company
+WHERE mentor_id IS NOT NULL
+ON CONFLICT (mentoring_company_id, mentor_id) DO NOTHING;
+
+-- 옛 컬럼/인덱스 제거 (FK 는 컬럼과 함께 제거됨)
+DROP INDEX IF EXISTS public.mentoring_company_mentor_id_idx;
+ALTER TABLE public.mentoring_company DROP COLUMN IF EXISTS mentor_id;
+ALTER TABLE public.mentoring_company DROP COLUMN IF EXISTS claimed_at;

--- a/types_db.ts
+++ b/types_db.ts
@@ -292,27 +292,21 @@ export type Database = {
       }
       mentoring_company: {
         Row: {
-          claimed_at: string | null
           company_id: number
           created_at: string
           id: number
-          mentor_id: string | null
           mentoring_id: string
         }
         Insert: {
-          claimed_at?: string | null
           company_id: number
           created_at?: string
           id?: number
-          mentor_id?: string | null
           mentoring_id: string
         }
         Update: {
-          claimed_at?: string | null
           company_id?: number
           created_at?: string
           id?: number
-          mentor_id?: string | null
           mentoring_id?: string
         }
         Relationships: [
@@ -324,17 +318,49 @@ export type Database = {
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "mentoring_company_mentor_id_fkey"
-            columns: ["mentor_id"]
-            isOneToOne: false
-            referencedRelation: "user"
-            referencedColumns: ["id"]
-          },
-          {
             foreignKeyName: "mentoring_company_mentoring_id_fkey"
             columns: ["mentoring_id"]
             isOneToOne: false
             referencedRelation: "mentoring"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      mentoring_company_mentor: {
+        Row: {
+          claimed_at: string | null
+          created_at: string
+          id: number
+          mentor_id: string
+          mentoring_company_id: number
+        }
+        Insert: {
+          claimed_at?: string | null
+          created_at?: string
+          id?: number
+          mentor_id: string
+          mentoring_company_id: number
+        }
+        Update: {
+          claimed_at?: string | null
+          created_at?: string
+          id?: number
+          mentor_id?: string
+          mentoring_company_id?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "mentoring_company_mentor_mentoring_company_id_fkey"
+            columns: ["mentoring_company_id"]
+            isOneToOne: false
+            referencedRelation: "mentoring_company"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "mentoring_company_mentor_mentor_id_fkey"
+            columns: ["mentor_id"]
+            isOneToOne: false
+            referencedRelation: "user"
             referencedColumns: ["id"]
           },
         ]


### PR DESCRIPTION
## 개요

멘토링에서 **한 기업을 여러 멘토가 함께 맡을 수 있도록** 기업↔멘토 배정을 1:1 → N:M으로 전환합니다. 멘토 셀프 claim 기능은 제거하고 **관리자 배정만** 남깁니다. 세션 회차는 기업 단위 공유를 유지합니다.

> 설계: `docs/superpowers/specs/2026-06-01-multi-mentor-per-company-design.md`
> 계획: `docs/superpowers/plans/2026-06-01-multi-mentor-per-company.md`
> ⚠️ 이 PR은 #17(PDF 수정) 위에 쌓여 있어 base가 `fix/mentoring-pdf-image-representative`입니다. #17 머지 후 base가 main으로 재타겟됩니다.

## 변경 사항

### 데이터 모델
- 배정 전용 조인 테이블 `mentoring_company_mentor` 신설 (`UNIQUE(mentoring_company_id, mentor_id)`)
- 기존 단일 배정 데이터 이관 후 `mentoring_company`에서 `mentor_id`/`claimed_at` 컬럼 제거
- `mentoring_session` 스키마는 변경 없음(회차 기업 단위 공유 유지, `mentor_id`=작성자)

### 서버 액션 (`mentoring-action.ts`)
- `MentoringAssignment`를 `mentors: MentoringAssignmentMentor[]` 배열 구조로 변경, `can_claim` 제거
- `getMentoringDetail`/`getMentoringByProgramId`/`getAllMentorings` 배정 조회를 조인 테이블 기반으로 변경
- **`setMentoringCompanyMentors`** 신설: 기업별 멘토 일괄 배정(diff 방식), 기록 있는 멘토는 해제 차단, 참여 멘토만 배정
- `claimMentoringCompany` 제거
- `upsertMentoringSession` 권한 체크를 "이 기업의 멘토 중 하나인지"로 변경
- `updateMentoringUsers` 제거 가드를 조인 테이블 기준으로 변경

### UI
- 관리자: 기업별 단일 Select → **멘토 체크박스 다중 선택**
- 멘토 홈: claim 섹션 제거, "담당 ○○ 외 N명" 다중 표기

## ⚠️ 머지 전 필수 작업

이 PR은 **마이그레이션 SQL 파일 생성 + `types_db.ts` 수동 반영**만 포함합니다. 실제 Supabase DB에는 아직 적용되지 않았습니다. **머지/배포 전 `supabase/migrations/20260601000000_multi_mentor_per_company.sql`를 실제 DB에 적용**해야 합니다.

## 테스트

- `pnpm type-check` / `pnpm lint` / `pnpm build` 모두 통과
- 수동 테스트(마이그레이션 적용 후 필요):
  - [ ] 기존 단일 배정이 조인 테이블로 정확히 이관
  - [ ] 한 기업에 멘토 2명 배정 → 두 멘토 모두 홈에서 조회
  - [ ] 두 멘토가 같은 기업에 세션 작성 → 회차 기업 단위로 이어짐, 작성자 구분
  - [ ] 세션 작성한 멘토 배정 해제 시도 → 차단
  - [ ] claim UI/엔드포인트 완전 제거 확인
  - [ ] PDF 각 세션 작성자 정확 표기
