### PR TITLE
ci: release PR 자동 머지

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,6 +18,10 @@ jobs:
         id: release
         uses: googleapis/release-please-action@v4
         with:
+          # PAT 를 사용해야 자동 머지된 push 가 다음 워크플로 실행을 트리거하고,
+          # 그 실행에서 git 태그와 GitHub Release 가 생성된다.
+          # (기본 GITHUB_TOKEN 으로 만든 push 는 워크플로를 트리거하지 못함)
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
@@ -25,7 +29,7 @@ jobs:
       - name: Auto-merge release PR
         if: ${{ steps.release.outputs.pr }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: |
           gh pr merge "${{ fromJson(steps.release.outputs.pr).number }}" \
             --repo "${{ github.repository }}" \

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,7 +15,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run release-please
+        id: release
         uses: googleapis/release-please-action@v4
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # release-please 가 생성/갱신한 release PR 을 사람이 직접 머지하지 않고 자동으로 머지한다.
+      - name: Auto-merge release PR
+        if: ${{ steps.release.outputs.pr }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge "${{ fromJson(steps.release.outputs.pr).number }}" \
+            --repo "${{ github.repository }}" \
+            --squash


### PR DESCRIPTION
## 개요

release-please 가 main push 시 생성/갱신하는 **release PR 을 자동으로 squash 머지**하도록 워크플로에 단계를 추가합니다. 지금은 release PR 이 만들어지면 사람이 직접 머지해야 합니다.

## 변경
`.github/workflows/release-please.yml` 에 release-please 액션 뒤로 다음 단계 추가:
- release PR 이 존재할 때(`steps.release.outputs.pr`) `gh pr merge --squash` 로 자동 머지

## ⚠️ 참고: 태그/GitHub Release 생성
기본 `GITHUB_TOKEN` 으로 머지하면 그 머지 push 는 새 워크플로 실행을 트리거하지 않습니다(GitHub 정책). 따라서 **버전 bump·CHANGELOG 커밋은 자동 머지되지만, git 태그와 GitHub Release 는 다음 main push 때 생성**됩니다.

태그/Release 까지 즉시 자동화하려면 PAT 가 필요합니다:
1. contents·pull-requests write 권한의 fine-grained PAT 생성
2. 레포 secret 으로 추가 (예: `RELEASE_PLEASE_TOKEN`)
3. 워크플로의 release-please 액션과 머지 단계 모두 해당 토큰 사용

원하시면 PAT 방식으로 업그레이드해 드리겠습니다.