### PR TITLE
ci: 열린 release PR 자동 머지 로직 보강

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,12 +25,20 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-      # release-please 가 생성/갱신한 release PR 을 사람이 직접 머지하지 않고 자동으로 머지한다.
+      # release-please 가 열어둔 release PR 을 사람이 직접 머지하지 않고 자동으로 머지한다.
+      # action 출력에 의존하면 "이번 실행에서 새로 만든 PR"만 잡혀서, 이전 실행에
+      # 만들어져 열려 있는 release PR 은 놓친다. 그래서 autorelease: pending 라벨이
+      # 붙은 열린 release PR 을 직접 찾아 머지한다.
       - name: Auto-merge release PR
-        if: ${{ steps.release.outputs.pr }}
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
-          gh pr merge "${{ fromJson(steps.release.outputs.pr).number }}" \
-            --repo "${{ github.repository }}" \
-            --squash
+          pr=$(gh pr list --repo "$REPO" --state open \
+            --label "autorelease: pending" --json number --jq '.[0].number // empty')
+          if [ -n "$pr" ]; then
+            echo "Auto-merging release PR #$pr"
+            gh pr merge "$pr" --repo "$REPO" --squash
+          else
+            echo "No open release PR to merge."
+          fi


### PR DESCRIPTION
이전 #19 의 자동 머지 스텝은 `steps.release.outputs.pr`(이번 실행에서 새로 만든 PR)에만 동작해, 구 워크플로가 만들어 둔 열린 release PR(#20)을 머지하지 못했습니다. `autorelease: pending` 라벨이 붙은 열린 release PR 을 직접 찾아 squash 머지하도록 변경합니다.

이 PR 이 머지되면 그 push 실행에서 새 로직이 열린 #20(release 0.3.0)을 자동 머지 → 태그/Release 0.3.0 이 생성됩니다.