### PR TITLE
feat: 멘토링 보고서 일괄 저장 병렬 처리 + 기업별 폴더·멘토명 파일명

### DIFF
--- a/src/app/(admin)/admin/program/[programId]/mentoring/page.tsx
+++ b/src/app/(admin)/admin/program/[programId]/mentoring/page.tsx
@@ -306,16 +306,56 @@ export default function Page({ params }: Props) {
       ]);
 
       const zip = new JSZip();
+      const sessions = mentoringDetail.sessions;
 
-      for (const session of mentoringDetail.sessions) {
-        const reportFile = await createSessionReportBlob(session.id);
-        zip.file(reportFile.fileName, reportFile.blob);
+      // 보고서 생성(서버 presign + react-pdf 렌더 + 이미지 fetch)을 동시성 제한으로
+      // 병렬 처리한다. 무제한 병렬은 메모리/서버 부하가 커서 동시 실행을 5개로 제한하고,
+      // 한 건이 실패해도 나머지는 zip 에 담는다.
+      const CONCURRENCY = 5;
+      const reports = new Array<{ fileName: string; blob: Blob } | null>(
+        sessions.length
+      );
+      let cursor = 0;
+      let failedCount = 0;
+
+      const worker = async () => {
+        while (cursor < sessions.length) {
+          const index = cursor;
+          cursor += 1;
+          try {
+            reports[index] = await createSessionReportBlob(sessions[index].id);
+          } catch (reportError) {
+            console.error(reportError);
+            failedCount += 1;
+          }
+        }
+      };
+
+      await Promise.all(
+        Array.from({ length: Math.min(CONCURRENCY, sessions.length) }, worker)
+      );
+
+      reports.forEach((report) => {
+        if (report) {
+          zip.file(report.fileName, report.blob);
+        }
+      });
+
+      if (failedCount === sessions.length) {
+        throw new Error("모든 멘토링 보고서 생성에 실패했습니다.");
       }
 
       const zipBlob = await zip.generateAsync({ type: "blob" });
       const date = new Date().toISOString().slice(0, 10);
       saveAs(zipBlob, `멘토링보고서_${mentoring.program.name}_${date}.zip`);
-      toast.success("멘토링 보고서 일괄 저장이 완료되었습니다.");
+
+      if (failedCount > 0) {
+        toast.warning(
+          `멘토링 보고서 일괄 저장을 완료했습니다. (${failedCount}건 실패, 나머지는 저장됨)`
+        );
+      } else {
+        toast.success("멘토링 보고서 일괄 저장이 완료되었습니다.");
+      }
     } catch (downloadError) {
       console.error(downloadError);
       toast.error("멘토링 보고서 일괄 저장 중 오류가 발생했습니다.");

--- a/src/app/(admin)/admin/program/[programId]/mentoring/page.tsx
+++ b/src/app/(admin)/admin/program/[programId]/mentoring/page.tsx
@@ -203,11 +203,19 @@ export default function Page({ params }: Props) {
     }
   };
 
+  // 폴더/파일명에 쓸 수 없는 문자를 치환한다(특히 '/' 는 의도치 않은 폴더를 만든다).
+  const sanitizeForPath = (value: string) =>
+    value.replace(/[\\/:*?"<>|]/g, "_").trim() || "미상";
+
   const buildSessionFileName = (
     companyName: string,
+    mentorName: string | null,
     sessionNo: number,
     date: string
-  ) => `${companyName}_멘토링일지_${sessionNo}회차_${date.slice(0, 10)}.pdf`;
+  ) =>
+    `${sanitizeForPath(companyName)}_${sanitizeForPath(
+      mentorName ?? "멘토미상"
+    )}_멘토링일지_${sessionNo}회차_${date.slice(0, 10)}.pdf`;
 
   const createSessionReportBlob = async (sessionId: number) => {
     if (!mentoringDetail) {
@@ -261,8 +269,10 @@ export default function Page({ params }: Props) {
 
     return {
       blob,
+      companyName: session.company_name,
       fileName: buildSessionFileName(
         session.company_name,
+        session.mentor_name,
         session.session_no,
         session.mentored_at
       ),
@@ -312,9 +322,11 @@ export default function Page({ params }: Props) {
       // 병렬 처리한다. 무제한 병렬은 메모리/서버 부하가 커서 동시 실행을 5개로 제한하고,
       // 한 건이 실패해도 나머지는 zip 에 담는다.
       const CONCURRENCY = 5;
-      const reports = new Array<{ fileName: string; blob: Blob } | null>(
-        sessions.length
-      );
+      const reports = new Array<{
+        fileName: string;
+        blob: Blob;
+        companyName: string;
+      } | null>(sessions.length);
       let cursor = 0;
       let failedCount = 0;
 
@@ -335,9 +347,13 @@ export default function Page({ params }: Props) {
         Array.from({ length: Math.min(CONCURRENCY, sessions.length) }, worker)
       );
 
+      // 기업별 폴더 안에 해당 기업의 세션 보고서를 저장한다.
       reports.forEach((report) => {
         if (report) {
-          zip.file(report.fileName, report.blob);
+          zip.file(
+            `${sanitizeForPath(report.companyName)}/${report.fileName}`,
+            report.blob
+          );
         }
       });
 


### PR DESCRIPTION
## 개요
관리자 멘토링 보고서 **일괄 저장**을 개선합니다. (1) 순차 처리를 동시성 제한 병렬로 전환해 속도 개선, (2) zip 을 기업별 폴더로 구조화, (3) 파일명에 작성자(멘토) 이름 추가.

## 변경
### 1) 병렬 처리 (`handleBulkReportDownload`)
- 순차 for-await → **동시 5개 제한 워커 풀** (서버 presign·이미지 fetch I/O 를 겹쳐 단축)
- 무제한 `Promise.all` 대신 동시성 제한 → 메모리/UI 프리징/서버 버스트 방지
- **항목별 에러 허용**: 한 건 실패해도 나머지는 zip 에 담고 실패 건수를 `toast.warning` 으로 안내(전부 실패 시에만 에러)

### 2) 기업별 폴더 구조
- zip 안에서 `기업명/` 폴더를 만들고 그 안에 해당 기업의 세션 보고서를 저장

### 3) 파일명에 멘토 이름
- `기업명_멘토명_멘토링일지_N회차_날짜.pdf` 형식 (단일/행별 다운로드에도 동일 적용)
- 폴더/파일명에 못 쓰는 문자(`/ : * ? " < > |`)는 `sanitizeForPath` 로 치환 — '/' 가 의도치 않은 폴더를 만드는 문제 방지

## 참고
- presigned URL 만료는 이미 '다운로드 직전 재발급'으로 해결돼 있어, 병렬화는 순수 속도 개선입니다.

## 테스트
- `pnpm type-check` / `lint` 통과
- [ ] 세션 다수 일괄 저장 → zip 이 `기업명/기업명_멘토명_...pdf` 구조, 순차 대비 빠름
- [ ] 일부 세션 실패 → 나머지 저장 + 실패 건수 토스트
- [ ] 기업명/멘토명에 특수문자 있어도 폴더/파일 정상