### PR TITLE
feat: 관리자 멘토링 세션 인라인 수정 + 페이지 이동 top loader 도입

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "lodash": "^4.17.21",
     "lucide-react": "^0.441.0",
     "next": "^16.1.6",
+    "nextjs-toploader": "^3.9.17",
     "primereact": "^10.9.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
       next:
         specifier: ^16.1.6
         version: 16.1.6(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      nextjs-toploader:
+        specifier: ^3.9.17
+        version: 3.9.17(next@16.1.6(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       primereact:
         specifier: ^10.9.1
         version: 10.9.7(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -3396,6 +3399,13 @@ packages:
       sass:
         optional: true
 
+  nextjs-toploader@3.9.17:
+    resolution: {integrity: sha512-9OF0KSSLtoSAuNg2LZ3aTl4hR9mBDj5L9s9DZiFCbMlXehyICGjkIz5dVGzuATU2bheJZoBdFgq9w07AKSuQQw==}
+    peerDependencies:
+      next: '>= 6.0.0'
+      react: '>= 16.0.0'
+      react-dom: '>= 16.0.0'
+
   node-abi@3.87.0:
     resolution: {integrity: sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==}
     engines: {node: '>=10'}
@@ -3408,6 +3418,9 @@ packages:
 
   normalize-svg-path@1.1.0:
     resolution: {integrity: sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==}
+
+  nprogress@0.2.0:
+    resolution: {integrity: sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -7979,6 +7992,14 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  nextjs-toploader@3.9.17(next@16.1.6(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      next: 16.1.6(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      nprogress: 0.2.0
+      prop-types: 15.8.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   node-abi@3.87.0:
     dependencies:
       semver: 7.7.4
@@ -7992,6 +8013,8 @@ snapshots:
   normalize-svg-path@1.1.0:
     dependencies:
       svg-arc-to-cubic-bezier: 3.2.0
+
+  nprogress@0.2.0: {}
 
   object-assign@4.1.1: {}
 

--- a/src/actions/mentoring-action.ts
+++ b/src/actions/mentoring-action.ts
@@ -1742,6 +1742,11 @@ export async function upsertMentoringSessionByAdmin(args: {
   mentoredAt: string;
   place?: string | null;
   content?: string | null;
+  photos: Array<{
+    photo_path: string;
+    original_filename?: string | null;
+    sort_order?: number;
+  }>;
 }) {
   return withActionResult(async () => {
     const context = await assertAdmin();
@@ -1772,6 +1777,35 @@ export async function upsertMentoringSessionByAdmin(args: {
         throw new Error("같은 기업에 동일한 회차가 이미 존재합니다.");
       }
       raiseActionError(updateError);
+    }
+
+    // 사진은 "기존 전부 삭제 → 새 목록 삽입" 방식으로 교체한다.
+    // 클라이언트가 유지할 기존 사진은 photo_path 를 그대로 다시 넘겨준다.
+    const { error: deletePhotoError } = await context.supabase
+      .from("mentoring_session_photo")
+      .delete()
+      .eq("mentoring_session_id", args.sessionId);
+
+    if (deletePhotoError) {
+      raiseActionError(deletePhotoError);
+    }
+
+    if (args.photos.length > 0) {
+      const { error: insertPhotoError } = await context.supabase
+        .from("mentoring_session_photo")
+        .insert(
+          args.photos.map((photo, index) => ({
+            mentoring_session_id: args.sessionId,
+            photo_path: photo.photo_path,
+            original_filename: photo.original_filename ?? null,
+            sort_order: photo.sort_order ?? index + 1,
+            created_at: new Date().toISOString(),
+          }))
+        );
+
+      if (insertPhotoError) {
+        raiseActionError(insertPhotoError);
+      }
     }
 
     return undefined;

--- a/src/app/(admin)/admin/[judgingRoundId]/page.tsx
+++ b/src/app/(admin)/admin/[judgingRoundId]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useParams, useRouter } from "next/navigation";
+import { useParams } from "next/navigation";
+import { useRouter } from "nextjs-toploader/app";
 import {
   Accordion,
   AccordionContent,

--- a/src/app/(admin)/admin/program/[programId]/judging/page.tsx
+++ b/src/app/(admin)/admin/program/[programId]/judging/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { use, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter } from "nextjs-toploader/app";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { executeAction, getErrorMessage } from "@/lib/action";

--- a/src/app/(admin)/admin/program/[programId]/mentoring/_components/MentoringSessionCard.tsx
+++ b/src/app/(admin)/admin/program/[programId]/mentoring/_components/MentoringSessionCard.tsx
@@ -1,0 +1,508 @@
+"use client";
+/* eslint-disable @next/next/no-img-element */
+
+import { useEffect, useRef, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { executeAction, getErrorMessage } from "@/lib/action";
+import {
+  createMentoringSessionPhotoUploadUrl,
+  type MentoringSession,
+  upsertMentoringSessionByAdmin,
+} from "@/actions/mentoring-action";
+import { mentoringQueries } from "@/queries";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { LoadingButton } from "@/components/ui/loading-button";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import {
+  Camera,
+  FileImage,
+  FileText,
+  MapPin,
+  Pencil,
+  Plus,
+  Trash2,
+  UserRound,
+  X,
+} from "lucide-react";
+
+// ISO 문자열을 datetime-local input 값(YYYY-MM-DDTHH:mm)으로 변환한다.
+function toLocalInputValue(dateString?: string | null) {
+  const date = dateString ? new Date(dateString) : new Date();
+  const offset = date.getTimezoneOffset();
+  return new Date(date.getTime() - offset * 60_000).toISOString().slice(0, 16);
+}
+
+function isWebpFile(file: File) {
+  return (
+    file.type.toLowerCase() === "image/webp" ||
+    file.name.toLowerCase().endsWith(".webp")
+  );
+}
+
+type EditorPhotoItem =
+  | {
+      key: string;
+      kind: "existing";
+      name: string;
+      previewUrl: string;
+      photoPath: string;
+    }
+  | {
+      key: string;
+      kind: "new";
+      name: string;
+      previewUrl: string;
+      fileKey: string;
+    };
+
+type Props = {
+  session: MentoringSession;
+  companyName: string;
+  mentoringId: string;
+  isDownloading: boolean;
+  isDeleting: boolean;
+  onDownloadReport: () => void;
+  onDelete: () => void;
+};
+
+export default function MentoringSessionCard({
+  session,
+  companyName,
+  mentoringId,
+  isDownloading,
+  isDeleting,
+  onDownloadReport,
+  onDelete,
+}: Props) {
+  const queryClient = useQueryClient();
+  const [isEditing, setIsEditing] = useState(false);
+  const [sessionNo, setSessionNo] = useState(String(session.session_no));
+  const [mentoredAt, setMentoredAt] = useState(
+    toLocalInputValue(session.mentored_at)
+  );
+  const [place, setPlace] = useState(session.place ?? "");
+  const [content, setContent] = useState(session.content ?? "");
+  const [editorPhotos, setEditorPhotos] = useState<EditorPhotoItem[]>([]);
+  const newPhotoFilesRef = useRef<
+    Record<string, { file: File; previewUrl: string }>
+  >({});
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  // 새 사진 미리보기로 만든 objectURL 을 정리해 메모리 누수를 방지한다.
+  const clearEditorPhotos = () => {
+    Object.values(newPhotoFilesRef.current).forEach((item) => {
+      URL.revokeObjectURL(item.previewUrl);
+    });
+    newPhotoFilesRef.current = {};
+    setEditorPhotos([]);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
+
+  // 언마운트 시 남아 있는 미리보기 objectURL 을 정리한다.
+  useEffect(() => () => clearEditorPhotos(), []);
+
+  const resetForm = () => {
+    setSessionNo(String(session.session_no));
+    setMentoredAt(toLocalInputValue(session.mentored_at));
+    setPlace(session.place ?? "");
+    setContent(session.content ?? "");
+  };
+
+  const startEditing = () => {
+    resetForm();
+    clearEditorPhotos();
+    setEditorPhotos(
+      session.photos.map((photo) => ({
+        key: `existing-${photo.id}`,
+        kind: "existing" as const,
+        name: photo.original_filename || "사진",
+        previewUrl: photo.download_url ?? photo.photo_path,
+        photoPath: photo.photo_path,
+      }))
+    );
+    setIsEditing(true);
+  };
+
+  const cancelEditing = () => {
+    resetForm();
+    clearEditorPhotos();
+    setIsEditing(false);
+  };
+
+  const handlePhotoFileChange = (files: FileList | null) => {
+    const selectedFiles = Array.from(files ?? []);
+    const allowedFiles = selectedFiles.filter((file) => !isWebpFile(file));
+
+    if (allowedFiles.length !== selectedFiles.length) {
+      toast.error(
+        "WEBP 이미지는 업로드할 수 없습니다. PNG 또는 JPG 파일을 사용해주세요."
+      );
+    }
+
+    if (allowedFiles.length === 0) {
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      return;
+    }
+
+    const added = allowedFiles.map((file, index) => {
+      const fileKey =
+        typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+          ? crypto.randomUUID()
+          : `photo-${index}-${file.name}`;
+      const previewUrl = URL.createObjectURL(file);
+      newPhotoFilesRef.current[fileKey] = { file, previewUrl };
+
+      return {
+        key: `new-${fileKey}`,
+        kind: "new" as const,
+        name: file.name,
+        previewUrl,
+        fileKey,
+      };
+    });
+    setEditorPhotos((current) => [...current, ...added]);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  const handleRemovePhoto = (key: string) => {
+    setEditorPhotos((current) => {
+      const target = current.find((item) => item.key === key);
+      if (target?.kind === "new") {
+        const fileEntry = newPhotoFilesRef.current[target.fileKey];
+        if (fileEntry) {
+          URL.revokeObjectURL(fileEntry.previewUrl);
+          delete newPhotoFilesRef.current[target.fileKey];
+        }
+      }
+      return current.filter((item) => item.key !== key);
+    });
+  };
+
+  const saveMutation = useMutation({
+    mutationFn: async () => {
+      const parsedSessionNo = Number(sessionNo);
+      if (!Number.isFinite(parsedSessionNo) || parsedSessionNo <= 0) {
+        throw new Error("회차는 1 이상의 숫자여야 합니다.");
+      }
+      if (!mentoredAt) {
+        throw new Error("멘토링 일시를 입력해 주세요.");
+      }
+
+      // 새로 추가된 사진만 S3 에 업로드하고, 기존 사진은 photo_path 를 그대로 유지한다.
+      const uploadedPhotos = await Promise.all(
+        editorPhotos.map(async (photoItem, index) => {
+          if (photoItem.kind === "existing") {
+            return {
+              photo_path: photoItem.photoPath,
+              original_filename: photoItem.name,
+              sort_order: index + 1,
+            };
+          }
+
+          const fileEntry = newPhotoFilesRef.current[photoItem.fileKey];
+          if (!fileEntry) return null;
+
+          const { uploadUrl, publicUrl } = await executeAction(
+            createMentoringSessionPhotoUploadUrl({
+              fileName: fileEntry.file.name,
+              contentType: fileEntry.file.type,
+            })
+          );
+
+          const uploadResponse = await fetch(uploadUrl, {
+            method: "PUT",
+            headers: {
+              "Content-Type": fileEntry.file.type || "image/jpeg",
+            },
+            body: fileEntry.file,
+          });
+
+          if (!uploadResponse.ok) {
+            throw new Error("사진 업로드에 실패했습니다.");
+          }
+
+          return {
+            photo_path: publicUrl,
+            original_filename: fileEntry.file.name,
+            sort_order: index + 1,
+          };
+        })
+      ).then((results) => results.filter((r) => r !== null));
+
+      return executeAction(
+        upsertMentoringSessionByAdmin({
+          sessionId: session.id,
+          mentoringId,
+          sessionNo: parsedSessionNo,
+          mentoredAt: new Date(mentoredAt).toISOString(),
+          place,
+          content,
+          photos: uploadedPhotos,
+        })
+      );
+    },
+    onSuccess: () => {
+      toast.success("멘토링 기록을 수정했습니다.");
+      clearEditorPhotos();
+      setIsEditing(false);
+      queryClient.invalidateQueries({ queryKey: mentoringQueries.all() });
+    },
+    onError: (err: unknown) => {
+      toast.error(getErrorMessage(err, "멘토링 기록 수정에 실패했습니다."));
+    },
+  });
+
+  if (isEditing) {
+    return (
+      <article className="rounded-xl border border-neutral-300 bg-white p-4 shadow-sm ring-1 ring-neutral-200">
+        <div className="flex items-center justify-between gap-2">
+          <p className="text-sm font-semibold text-neutral-900">
+            {companyName} · 기록 수정
+          </p>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="gap-1.5 text-neutral-500"
+            onClick={cancelEditing}
+            disabled={saveMutation.isPending}
+          >
+            <X className="h-4 w-4" />
+            취소
+          </Button>
+        </div>
+
+        <div className="mt-4 grid gap-4 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label htmlFor={`session-no-${session.id}`}>회차</Label>
+            <Input
+              id={`session-no-${session.id}`}
+              type="number"
+              min={1}
+              value={sessionNo}
+              onChange={(event) => setSessionNo(event.target.value)}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor={`mentored-at-${session.id}`}>멘토링 일시</Label>
+            <Input
+              id={`mentored-at-${session.id}`}
+              type="datetime-local"
+              value={mentoredAt}
+              onChange={(event) => setMentoredAt(event.target.value)}
+            />
+          </div>
+          <div className="space-y-1.5 sm:col-span-2">
+            <Label htmlFor={`place-${session.id}`}>장소</Label>
+            <Input
+              id={`place-${session.id}`}
+              type="text"
+              placeholder="멘토링 장소"
+              value={place}
+              onChange={(event) => setPlace(event.target.value)}
+            />
+          </div>
+          <div className="space-y-1.5 sm:col-span-2">
+            <Label htmlFor={`content-${session.id}`}>멘토링 내용</Label>
+            <Textarea
+              id={`content-${session.id}`}
+              rows={6}
+              placeholder="멘토링 내용을 입력하세요."
+              value={content}
+              onChange={(event) => setContent(event.target.value)}
+            />
+          </div>
+          <div className="space-y-1.5 sm:col-span-2">
+            <Label>사진</Label>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              multiple
+              tabIndex={-1}
+              className="sr-only"
+              onChange={(event) => handlePhotoFileChange(event.target.files)}
+            />
+            {editorPhotos.length === 0 ? (
+              <button
+                type="button"
+                className="flex w-full cursor-pointer items-center justify-center gap-2 rounded-xl border border-dashed border-neutral-300 bg-neutral-50 px-4 py-4 text-sm font-medium text-neutral-700 transition-colors hover:border-neutral-400 hover:bg-white"
+                onClick={() => fileInputRef.current?.click()}
+              >
+                <Camera className="h-4 w-4" />
+                사진 선택
+              </button>
+            ) : (
+              <div className="space-y-3">
+                <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+                  {editorPhotos.map((photo) => (
+                    <div
+                      key={photo.key}
+                      className="overflow-hidden rounded-2xl border border-neutral-200 bg-white"
+                    >
+                      <div className="relative aspect-[4/3] bg-neutral-100">
+                        <img
+                          src={photo.previewUrl}
+                          alt={photo.name}
+                          className="h-full w-full object-cover"
+                        />
+                        <div className="absolute top-2 left-2 rounded-full bg-black/65 px-2 py-1 text-[11px] font-medium text-white">
+                          {photo.kind === "existing" ? "기존 사진" : "새 사진"}
+                        </div>
+                        <button
+                          type="button"
+                          className="absolute top-2 right-2 rounded-full bg-white/90 px-2 py-1 text-xs font-medium text-neutral-700 hover:bg-white hover:text-red-500"
+                          onClick={() => handleRemovePhoto(photo.key)}
+                        >
+                          삭제
+                        </button>
+                      </div>
+                      <div className="flex items-center gap-2 border-t border-neutral-100 px-3 py-2 text-sm text-neutral-600">
+                        <FileImage className="h-4 w-4 shrink-0 text-neutral-400" />
+                        <span className="min-w-0 flex-1 truncate">
+                          {photo.name}
+                        </span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+                <button
+                  type="button"
+                  className="flex w-full cursor-pointer items-center justify-center gap-2 rounded-xl border border-dashed border-neutral-300 bg-neutral-50 px-4 py-3 text-sm font-medium text-neutral-600 transition-colors hover:border-neutral-400 hover:bg-white"
+                  onClick={() => fileInputRef.current?.click()}
+                >
+                  <Plus className="h-4 w-4" />
+                  사진 추가
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="mt-4 flex justify-end gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={cancelEditing}
+            disabled={saveMutation.isPending}
+          >
+            취소
+          </Button>
+          <LoadingButton
+            type="button"
+            size="sm"
+            loading={saveMutation.isPending}
+            onClick={() => saveMutation.mutate()}
+          >
+            저장
+          </LoadingButton>
+        </div>
+      </article>
+    );
+  }
+
+  return (
+    <article className="rounded-xl border border-neutral-200 bg-white p-4 shadow-sm">
+      <div className="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="secondary">{session.session_no}회차</Badge>
+            <span className="text-sm font-medium text-neutral-900">
+              {session.mentored_at.slice(0, 16).replace("T", " ")}
+            </span>
+          </div>
+          <div className="mt-2 flex flex-wrap gap-3 text-sm text-neutral-500">
+            <span className="flex items-center gap-1">
+              <UserRound className="h-3.5 w-3.5" />
+              {session.mentor_name || "작성자 없음"}
+            </span>
+            <span className="flex items-center gap-1">
+              <MapPin className="h-3.5 w-3.5" />
+              {session.place || "장소 미입력"}
+            </span>
+          </div>
+          {session.content && (
+            <p className="mt-2 line-clamp-2 text-sm leading-6 text-neutral-600">
+              {session.content}
+            </p>
+          )}
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <LoadingButton
+            type="button"
+            variant="outline"
+            size="sm"
+            className="gap-1.5"
+            loading={isDownloading}
+            onClick={onDownloadReport}
+          >
+            <FileText className="h-4 w-4" />
+            보고서
+          </LoadingButton>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="gap-1.5"
+            onClick={startEditing}
+          >
+            <Pencil className="h-4 w-4" />
+            수정
+          </Button>
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="gap-1.5 text-red-600 hover:bg-red-50 hover:text-red-700"
+                disabled={isDeleting}
+              >
+                <Trash2 className="h-4 w-4" />
+                삭제
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>
+                  멘토링 세션을 삭제하시겠습니까?
+                </AlertDialogTitle>
+                <AlertDialogDescription>
+                  {companyName} · {session.session_no}회차 기록과 첨부된 사진이
+                  모두 삭제됩니다.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>취소</AlertDialogCancel>
+                <AlertDialogAction
+                  onClick={onDelete}
+                  className="bg-red-500 hover:bg-red-600"
+                >
+                  삭제
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/app/(admin)/admin/program/[programId]/mentoring/page.tsx
+++ b/src/app/(admin)/admin/program/[programId]/mentoring/page.tsx
@@ -24,32 +24,18 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "@/components/ui/alert-dialog";
-import {
   ArrowLeft,
   Building2,
   Clock3,
   Download,
   FileText,
-  MapPin,
-  Pencil,
   PlayCircle,
   SquareArrowOutUpRight,
   StopCircle,
-  Trash2,
-  UserRound,
 } from "lucide-react";
 import ProgramFeatureTabs from "../_components/ProgramFeatureTabs";
 import MentoringEditForm from "../_components/MentoringEditForm";
+import MentoringSessionCard from "./_components/MentoringSessionCard";
 import MentoringSessionDocument from "@/app/(home)/mentoring/[mentoringId]/_components/MentoringSessionDocument";
 import {
   Select,
@@ -684,103 +670,18 @@ export default function Page({ params }: Props) {
                   </AccordionTrigger>
                   <AccordionContent className="space-y-3 pb-4">
                     {group.sessions.map((session) => (
-                      <article
+                      <MentoringSessionCard
                         key={session.id}
-                        className="rounded-xl border border-neutral-200 bg-white p-4 shadow-sm"
-                      >
-                        <div className="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
-                          <div className="min-w-0 flex-1">
-                            <div className="flex flex-wrap items-center gap-2">
-                              <Badge variant="secondary">
-                                {session.session_no}회차
-                              </Badge>
-                              <span className="text-sm font-medium text-neutral-900">
-                                {session.mentored_at
-                                  .slice(0, 16)
-                                  .replace("T", " ")}
-                              </span>
-                            </div>
-                            <div className="mt-2 flex flex-wrap gap-3 text-sm text-neutral-500">
-                              <span className="flex items-center gap-1">
-                                <UserRound className="h-3.5 w-3.5" />
-                                {session.mentor_name || "작성자 없음"}
-                              </span>
-                              <span className="flex items-center gap-1">
-                                <MapPin className="h-3.5 w-3.5" />
-                                {session.place || "장소 미입력"}
-                              </span>
-                            </div>
-                            {session.content && (
-                              <p className="mt-2 line-clamp-2 text-sm leading-6 text-neutral-600">
-                                {session.content}
-                              </p>
-                            )}
-                          </div>
-                          <div className="flex flex-wrap gap-2">
-                            <LoadingButton
-                              type="button"
-                              variant="outline"
-                              size="sm"
-                              className="gap-1.5"
-                              loading={downloadingSessionId === session.id}
-                              onClick={() => handleSessionPdfDownload(session)}
-                            >
-                              <FileText className="h-4 w-4" />
-                              보고서
-                            </LoadingButton>
-                            <Button
-                              type="button"
-                              variant="outline"
-                              size="sm"
-                              className="gap-1.5"
-                              onClick={() =>
-                                router.push(
-                                  `/mentoring/${mentoring.id}?companyId=${session.company_id}`
-                                )
-                              }
-                            >
-                              <Pencil className="h-4 w-4" />
-                              수정
-                            </Button>
-                            <AlertDialog>
-                              <AlertDialogTrigger asChild>
-                                <Button
-                                  type="button"
-                                  variant="outline"
-                                  size="sm"
-                                  className="gap-1.5 text-red-600 hover:bg-red-50 hover:text-red-700"
-                                  disabled={adminDeleteMutation.isPending}
-                                >
-                                  <Trash2 className="h-4 w-4" />
-                                  삭제
-                                </Button>
-                              </AlertDialogTrigger>
-                              <AlertDialogContent>
-                                <AlertDialogHeader>
-                                  <AlertDialogTitle>
-                                    멘토링 세션을 삭제하시겠습니까?
-                                  </AlertDialogTitle>
-                                  <AlertDialogDescription>
-                                    {group.companyName} · {session.session_no}
-                                    회차 기록과 첨부된 사진이 모두 삭제됩니다.
-                                  </AlertDialogDescription>
-                                </AlertDialogHeader>
-                                <AlertDialogFooter>
-                                  <AlertDialogCancel>취소</AlertDialogCancel>
-                                  <AlertDialogAction
-                                    onClick={() =>
-                                      adminDeleteMutation.mutate(session.id)
-                                    }
-                                    className="bg-red-500 hover:bg-red-600"
-                                  >
-                                    삭제
-                                  </AlertDialogAction>
-                                </AlertDialogFooter>
-                              </AlertDialogContent>
-                            </AlertDialog>
-                          </div>
-                        </div>
-                      </article>
+                        session={session}
+                        companyName={group.companyName}
+                        mentoringId={mentoring.id}
+                        isDownloading={downloadingSessionId === session.id}
+                        isDeleting={adminDeleteMutation.isPending}
+                        onDownloadReport={() =>
+                          handleSessionPdfDownload(session)
+                        }
+                        onDelete={() => adminDeleteMutation.mutate(session.id)}
+                      />
                     ))}
                   </AccordionContent>
                 </AccordionItem>

--- a/src/app/(admin)/admin/program/[programId]/mentoring/page.tsx
+++ b/src/app/(admin)/admin/program/[programId]/mentoring/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { use, useMemo, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter } from "nextjs-toploader/app";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { executeAction, getErrorMessage } from "@/lib/action";

--- a/src/app/(admin)/admin/program/_components/ProgramColumns.tsx
+++ b/src/app/(admin)/admin/program/_components/ProgramColumns.tsx
@@ -39,7 +39,7 @@ import ProgramEditForm from "./ProgramEditForm";
 import { toast } from "sonner";
 import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter } from "nextjs-toploader/app";
 import { programQueries } from "@/queries";
 
 function ProgramManageCell({

--- a/src/app/(home)/_components/HomeClient.tsx
+++ b/src/app/(home)/_components/HomeClient.tsx
@@ -9,7 +9,7 @@ import ProgramSkeleton from "./ProgramSkeleton";
 import { JudgingCard } from "./judging-card";
 import WorkspaceTabs from "./WorkspaceTabs";
 import WorkspaceEmptyState from "./workspace-empty-state";
-import { useRouter } from "next/navigation";
+import { useRouter } from "nextjs-toploader/app";
 import {
   CalendarX2,
   Search,

--- a/src/app/(home)/judging/[judgingRoundId]/page.tsx
+++ b/src/app/(home)/judging/[judgingRoundId]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useParams, useRouter } from "next/navigation";
+import { useParams } from "next/navigation";
+import { useRouter } from "nextjs-toploader/app";
 import { useQuery } from "@tanstack/react-query";
 import { judgingQueries } from "@/queries";
 import { useAuthStore } from "@/store/useAuthStore";

--- a/src/app/(home)/mentoring/[mentoringId]/page.tsx
+++ b/src/app/(home)/mentoring/[mentoringId]/page.tsx
@@ -2,7 +2,8 @@
 /* eslint-disable @next/next/no-img-element */
 
 import { startTransition, useEffect, useMemo, useRef, useState } from "react";
-import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { useParams, useSearchParams } from "next/navigation";
+import { useRouter } from "nextjs-toploader/app";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { executeAction, getErrorMessage } from "@/lib/action";

--- a/src/app/(home)/mentoring/page.tsx
+++ b/src/app/(home)/mentoring/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter } from "nextjs-toploader/app";
 import { keepPreviousData, useInfiniteQuery } from "@tanstack/react-query";
 import { Delay } from "@suspensive/react";
 import { mentoringQueries } from "@/queries";

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
 import { Toaster } from "sonner";
+import NextTopLoader from "nextjs-toploader";
 import ReactQueryClientProvider from "@/config/ReactQueryClientProvider";
 import { AuthProvider } from "@/app/_components/AuthProvider";
 import "core-js/full/promise/with-resolvers";
@@ -43,6 +44,12 @@ export default async function RootLayout({
         )}
       </head>
       <body className={`${pretendard.className} antialiased`}>
+        <NextTopLoader
+          color="#4f46e5"
+          height={3}
+          shadow="0 0 10px #4f46e5, 0 0 5px #4f46e5"
+          showSpinner={false}
+        />
         <ReactQueryClientProvider>
           <AuthProvider>
             <Toaster richColors />


### PR DESCRIPTION
## 요약

두 가지 UX 개선을 담았습니다.

### 1. 관리자 멘토링 세션 인라인 수정 (`91e6133`, `189fb47`)

기존에는 admin 멘토링 페이지에서 "수정" 버튼을 누르면 멘토 화면(`/mentoring/[id]`)으로 페이지가 이동해 별도 화면에서 고쳐야 했습니다. 이제 같은 자리에서 바로 편집합니다.

- **`MentoringSessionCard` 신설**: 세션 article을 표시/편집 모드를 자체 토글하는 컴포넌트로 분리. "수정" 클릭 시 회차/일시/장소/내용 입력 + 사진 갤러리(기존·새 사진, 개별 삭제, 추가)로 전환
- **사진 편집**: 새 사진만 S3 presigned 업로드 후 저장, 기존 사진은 `photo_path` 유지. 미리보기 objectURL은 삭제·취소·언마운트 시 revoke
- **`upsertMentoringSessionByAdmin` 확장**: `photos`를 받아 "기존 전부 삭제 → 새 목록 삽입" 방식으로 교체. `assertAdmin` 기반이라 작성자가 아닌 관리자도 수정 가능 (멘토 본인 체크가 있는 `upsertMentoringSession`과 구분)

### 2. 페이지 이동 top loader (`d8f1f4b`, `d1992e7`)

GitHub/YouTube 스타일의 상단 progress bar를 도입했습니다 (`nextjs-toploader`, 인디고 `#4f46e5`).

- root layout에 `<NextTopLoader />` 추가 → `<Link>` 이동 시 바 표시
- top loader는 `<a>` 클릭만 감지하므로, 버튼 `onClick`의 `router.push()` 이동 8개 파일 12곳은 `nextjs-toploader/app`의 래핑된 `useRouter`로 교체해 일관되게 바가 뜨도록 함 (API 100% 호환, import만 변경)
- **의도적 제외**: upload의 `?id=` 검색(페이지 이동이 아닌 같은 화면 내 검색 — React Query 스피너/Skeleton이 이미 표시), admin 뒤로가기의 `router.back()`(캐시 복원이라 바 불필요)

## 테스트 플랜

- [x] `pnpm type-check` / `pnpm lint` (pre-commit 훅, 커밋마다 통과)
- [x] admin 멘토링 인라인 수정: 텍스트 필드 수정 → 저장 → 목록 반영 확인
- [ ] admin 인라인 사진 편집: 기존 사진 삭제 + 새 사진 추가 → 저장 → 보고서 PDF에 반영 확인
- [ ] 인라인 수정 "취소" 시 원래 값 복원 확인
- [x] top loader: `<Link>` 및 `router.push` 이동(행/카드 클릭, 목록 복귀 버튼)에서 바 표시 확인
- [ ] upload `?id=` 검색에서 바가 뜨지 않는 것 확인
- [ ] 종료(COMPLETED)된 멘토링이 아닌 경우에만 admin 수정이 동작하는지 확인