### PR TITLE
fix: 참여 기업 전체 제거 시 DB 목록으로 되살아나던 버그 수정

### DIFF
--- a/src/app/(admin)/admin/program/_components/CompanySelectForModify.tsx
+++ b/src/app/(admin)/admin/program/_components/CompanySelectForModify.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useQuery, useInfiniteQuery } from "@tanstack/react-query";
 import { programQueries, companyQueries } from "@/queries";
 import { useInfiniteScroll } from "@/app/_hooks/useInfiniteScroll";
@@ -43,17 +43,22 @@ export default function CompanySelectForModify({
   });
   const sourceList = data?.pages.flatMap((page) => page.result) ?? [];
 
+  // 기존 참여 기업으로 targetList를 채우는 작업은 "최초 1회"만 수행한다.
+  // targetList.length === 0 을 초기화 신호로 쓰면, 사용자가 참여 기업을
+  // 전부 제거해 비운 순간에도 다시 DB 목록으로 복원되어 "제거가 안 되는" 버그가 발생한다.
+  const initializedRef = useRef(false);
+
   useEffect(() => {
-    if (!isLoading && allCompanies && allCompanies.length > 0) {
-      if (targetList.length === 0) {
-        const mapped = allCompanies.map((pc) => ({
-          id: pc.company_id,
-          name: pc.company?.name ?? `Company #${pc.company_id}`,
-        }));
-        onTargetListChange(mapped);
-      }
-    }
-  }, [isLoading, allCompanies, targetList.length, onTargetListChange]);
+    if (initializedRef.current) return;
+    if (isLoading || !allCompanies) return;
+
+    initializedRef.current = true;
+    const mapped = allCompanies.map((pc) => ({
+      id: pc.company_id,
+      name: pc.company?.name ?? `Company #${pc.company_id}`,
+    }));
+    onTargetListChange(mapped);
+  }, [isLoading, allCompanies, onTargetListChange]);
 
   const handleSelectSource = (id: number) => {
     setSelectedSourceIds((prev) =>


### PR DESCRIPTION
## 배경 (CS 대응)

현재 배포된 admin 패널의 **프로그램 수정 Sheet**에서, 참여 기업을 전체 기업 목록에서 추가한 뒤 다시 체크해 제거(←) 버튼을 눌러도 빠지지 않는다는 고객 신고가 있었다.

## 원인

`CompanySelectForModify.tsx`의 초기화 `useEffect`가 `targetList.length === 0`을 **"아직 초기화되지 않음"의 신호**로 사용했다.

- 사용자가 참여 기업을 전부 제거해 `targetList`가 비는 순간, effect가 "초기화가 필요하다"고 오판
- DB에 저장된 기존 기업 목록(`programQueries.companies`)으로 **자동 복원**
- 결과적으로 "체크하고 제거 버튼을 눌러도 안 빠진다"

**재현 조건:** 제거 동작으로 참여 기업 리스트가 비워질 때(전부 제거 / 마지막 하나 제거). 일부만 제거(빈 적 없음)·원래 비어있던 프로그램은 정상 → "어떤 경우엔 안 빠진다"는 신고와 일치.

## 수정

`length === 0` 센티넬 대신 **`useRef(false)` 초기화 플래그**를 도입해 기존 참여 기업 seed를 **최초 1회만** 수행하도록 변경. 이후에는 사용자가 리스트를 비워도 복원하지 않으며, edit 모드 초기 로딩 seed는 그대로 동작한다.

## 검증

- 컴포넌트 상태 전이를 추출한 시뮬레이션: 기존 로직은 "전부 제거" 케이스 FAIL → 수정 로직은 전 케이스(전부 제거 / 추가 후 전부 제거 / 부분 제거 / 빈 프로그램 / 초기 seed 유지) PASS
- `pnpm lint`, `pnpm type-check` 통과 (pre-commit 훅 포함)

## 테스트 플랜 (리뷰어 수동 확인)

- [ ] 기존 참여 기업이 있는 프로그램 수정 → 참여 기업 전부 체크 후 ← → 비워진 채 유지되는지
- [ ] 추가한 기업 + 기존 기업 섞어 전부 제거 → 모두 빠지는지
- [ ] 일부만 제거 시 정상 동작 유지
- [ ] 수정 후 "수정하기" 저장 시 비운 상태(참여 기업 0개)가 DB에 반영되는지